### PR TITLE
Enable multiple ecommerce connectors

### DIFF
--- a/docs/multi-connectors.md
+++ b/docs/multi-connectors.md
@@ -1,0 +1,50 @@
+# Multi-connector Support
+
+Connect Ecommerce now lets you configure and store multiple connectors, each with its own credentials, behaviour toggles, and workflow assignments. This document explains how to use the new admin UI and how developers can register additional connector types.
+
+## Managing connectors in the admin UI
+
+1. Open **WooCommerce → Connect Ecommerce → Settings → Connection**.
+2. Use the **Connectors** card to:
+   - Rename existing connectors, toggle product/order workflows, or mark a connector as inactive.
+   - Remove connectors that are no longer needed (settings are erased when removed).
+   - Add a new connector by selecting its type, giving it a label, and optionally providing a custom identifier.
+3. Pick the connector you want to configure from the dropdown at the top of the page. Only the selected connector’s settings fields are displayed.
+4. Save the form to persist changes. Each connector keeps its own set of credentials and automation flags.
+
+> **Tip:** The active connector is highlighted in the table. All synchronization screens continue to operate using the active connector’s configuration for backwards compatibility.
+
+## Workflow flags
+
+Every connector stores flags that describe which workflows it participates in:
+
+| Workflow | Description |
+| --- | --- |
+| Products | Enables the connector for product synchronisation (manual or cron). |
+| Orders | Enables the connector for order submission and invoice downloads. |
+
+The current release still executes tasks sequentially using the active connector, but the workflow flags make it easy to extend the behaviour (e.g. by iterating through connectors flagged as `products`).
+
+## Registering custom connector types
+
+Connector types are registered via the existing `conecom_options_plugin` filter, so third parties can expose new ERPs/CRMs without touching the core plugin. Each definition must expose at least a `name`, `slug`, and any capability flags used by the UI.
+
+```php
+add_filter( 'conecom_options_plugin', function( $options ) {
+	$options['myerp'] = array(
+		'name'                       => 'My ERP',
+		'slug'                       => 'conecom-myerp',
+		'plugin_name'                => 'Connect WooCommerce MyERP',
+		'plugin_slug'                => 'connect-ecommerce-myerp',
+		'api_pagination'             => 100,
+		'product_price_tax_option'   => true,
+		'product_option_stock'       => true,
+		'settings_admin_message'     => __( 'Enter the API credentials provided by MyERP.', 'woocommerce-es' ),
+		'settings_fields'            => array( 'apipassword', 'username' ),
+	);
+
+	return $options;
+} );
+```
+
+After registering the definition and loading its API class (`Connect_Ecommerce_MyERP`), the connector will appear in the admin **Add connector** dropdown and can be configured multiple times with different identifiers.

--- a/includes/Admin/Import_Products.php
+++ b/includes/Admin/Import_Products.php
@@ -175,11 +175,33 @@ class Import_Products {
 		$res_message    = '';
 		$generate_ai    = ! empty( $_POST['product_ai'] ) ? sanitize_key( $_POST['product_ai'] ) : 'none';
 		$generate_ai    = 'true' === $generate_ai ? 'all' : $generate_ai;
-		$api_pagination = ! empty( $this->options['api_pagination'] ) ? $this->options['api_pagination'] : false;
+
+		// Get connector from request or use default.
+		$connector_id = isset( $_POST['connector_id'] ) ? sanitize_text_field( wp_unslash( $_POST['connector_id'] ) ) : '';
+		if ( ! empty( $connector_id ) ) {
+			$connector_definitions = apply_filters( 'conecom_options_plugin', array() );
+			$connector_data        = HELPER::get_connector_by_id( $connector_id, $connector_definitions );
+			if ( $connector_data && isset( $connector_data['connapi_erp'] ) ) {
+				$connapi_erp    = $connector_data['connapi_erp'];
+				$settings       = $connector_data['settings'];
+				$options        = $connector_data['options'];
+				$api_pagination = ! empty( $options['api_pagination'] ) ? $options['api_pagination'] : false;
+			} else {
+				$connapi_erp    = $this->connapi_erp;
+				$settings       = $this->settings;
+				$options        = $this->options;
+				$api_pagination = ! empty( $this->options['api_pagination'] ) ? $this->options['api_pagination'] : false;
+			}
+		} else {
+			$connapi_erp    = $this->connapi_erp;
+			$settings       = $this->settings;
+			$options        = $this->options;
+			$api_pagination = ! empty( $this->options['api_pagination'] ) ? $this->options['api_pagination'] : false;
+		}
 
 		// Action for one product.
 		if ( ! empty( $product_erp_id ) ) {
-			$result_api = $this->connapi_erp->get_products( $product_erp_id );
+			$result_api = $connapi_erp->get_products( $product_erp_id );
 			if ( isset( $result_api['status'] ) && 'error' === $result_api['status'] ) {
 				wp_send_json_error( array( 'message' => __( 'Error getting product', 'woocommerce-es' ) . ': ' . $result_api['message'] ) );
 			}
@@ -187,8 +209,8 @@ class Import_Products {
 				wp_send_json_error( array( 'message' => 'No products' ) );
 			}
 			$api_products = array( -1 => $result_api );
-		} elseif ( ! empty( $product_sku ) && method_exists( $this->connapi_erp, 'get_product_by_sku' ) ) {
-			$result_api = $this->connapi_erp->get_product_by_sku( $product_sku );
+		} elseif ( ! empty( $product_sku ) && method_exists( $connapi_erp, 'get_product_by_sku' ) ) {
+			$result_api = $connapi_erp->get_product_by_sku( $product_sku );
 			if ( empty( $result_api ) ) {
 				wp_send_json_error( array( 'message' => 'No products' ) );
 			}
@@ -206,9 +228,9 @@ class Import_Products {
 		}
 
 		if ( 0 === $sync_loop || ( $api_pagination && 0 === $loop_page ) ) {
-			$api_products                     = $this->connapi_erp->get_products( null, $sync_loop );
+			$api_products                     = $connapi_erp->get_products( null, $sync_loop );
 			$_SESSION['conecom_api_products'] = HELPER::sanitize_array_recursive( $api_products );
-			$res_message             .= __( 'Connecting with API...', 'woocommerce-es' ) . '<br/>';
+			$res_message                     .= __( 'Connecting with API...', 'woocommerce-es' ) . '<br/>';
 		} elseif ( 0 < $sync_loop ) {
 			$api_products = isset( $_SESSION['conecom_api_products'] ) ? HELPER::sanitize_array_recursive( $_SESSION['conecom_api_products'] ) : array();
 		}
@@ -225,7 +247,7 @@ class Import_Products {
 		$item                     = $api_products[ $sync_loop - ( $api_pagination * $page ) ];
 		$this->msg_error_products = array();
 
-		$result_sync = PROD::sync_product_item( $this->settings, $item, $this->connapi_erp, $generate_ai, $product_id );
+		$result_sync = PROD::sync_product_item( $settings, $item, $connapi_erp, $generate_ai, $product_id );
 		$post_id     = $result_sync['post_id'] ?? 0;
 		if ( 'error' === $result_sync['status'] ) {
 			$this->error_product_import[] = array(
@@ -277,7 +299,7 @@ class Import_Products {
 		);
 		if ( $finish && 0 < $sync_loop ) {
 			// Email errors.
-			HELPER::send_product_errors( $this->error_product_import, $this->options['slug'] );
+			HELPER::send_product_errors( $this->error_product_import, $options['slug'] );
 		}
 		wp_send_json_success( $args );
 	}

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -136,6 +136,29 @@ class Orders {
 		$sync_loop    = isset( $_POST['loop'] ) ? (int) $_POST['loop'] : 0;
 		$message      = '';
 
+		// Get connector from request or use default.
+		$connector_id = isset( $_POST['connector_id'] ) ? sanitize_text_field( wp_unslash( $_POST['connector_id'] ) ) : '';
+		if ( ! empty( $connector_id ) ) {
+			$connector_definitions = apply_filters( 'conecom_options_plugin', array() );
+			$connector_data        = HELPER::get_connector_by_id( $connector_id, $connector_definitions );
+			if ( $connector_data && isset( $connector_data['connapi_erp'] ) ) {
+				$connapi_erp    = $connector_data['connapi_erp'];
+				$settings       = $connector_data['settings'];
+				$options        = $connector_data['options'];
+				$meta_key_order = '_' . $options['slug'] . '_invoice_id';
+			} else {
+				$connapi_erp    = $this->connapi_erp;
+				$settings       = $this->settings;
+				$options        = $this->options;
+				$meta_key_order = $this->meta_key_order;
+			}
+		} else {
+			$connapi_erp    = $this->connapi_erp;
+			$settings       = $this->settings;
+			$options        = $this->options;
+			$meta_key_order = $this->meta_key_order;
+		}
+
 		// Start.
 		if ( ! session_id() ) {
 			session_start();
@@ -184,22 +207,22 @@ class Orders {
 							)
 						);
 					} else {
-						die( esc_html( __( 'No orders to import', 'woocommerce-es' ) ) );
-					}
-				} else {
-					$ec_invoice_id = $order->get_meta( $this->meta_key_order );
-
-					if ( ! empty( $ec_invoice_id ) && 'nocreate' !== $ec_invoice_id ) {
-						$message .= __( 'Order already exported to API ID:', 'woocommerce-es' ) . $ec_invoice_id;
-					} elseif ( ! empty( $ec_invoice_id ) && 'nocreate' !== $ec_invoice_id ) {
-						$message .= __( 'Free order not exported', 'woocommerce-es' );
-					} else {
-						$result = ORDER::create_invoice( $this->settings, $item['id'], $this->meta_key_order, $this->options['slug'], $this->connapi_erp );
-
-						$message .= 'ok' === $result['status'] ? __( 'Order Created.', 'woocommerce-es' ) : __( 'Order not created.', 'woocommerce-es' );
-						$message .= ' ' . $result['message'];
-					}
+					die( esc_html( __( 'No orders to import', 'woocommerce-es' ) ) );
 				}
+			} else {
+				$ec_invoice_id = $order->get_meta( $meta_key_order );
+
+				if ( ! empty( $ec_invoice_id ) && 'nocreate' !== $ec_invoice_id ) {
+					$message .= __( 'Order already exported to API ID:', 'woocommerce-es' ) . $ec_invoice_id;
+				} elseif ( ! empty( $ec_invoice_id ) && 'nocreate' !== $ec_invoice_id ) {
+					$message .= __( 'Free order not exported', 'woocommerce-es' );
+				} else {
+					$result = ORDER::create_invoice( $settings, $item['id'], $meta_key_order, $options['slug'], $connapi_erp );
+
+					$message .= 'ok' === $result['status'] ? __( 'Order Created.', 'woocommerce-es' ) : __( 'Order not created.', 'woocommerce-es' );
+					$message .= ' ' . $result['message'];
+				}
+			}
 
 				if ( $doing_ajax || $not_sapi_cli ) {
 					$orders_synced = $sync_loop + 1;

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1133,17 +1133,52 @@ class Settings {
 					</div>
 					<?php
 				} else {
+					$is_orders = 'sync_orders' === $type;
+					$item_type = $is_orders ? __( 'Orders', 'woocommerce-es' ) : __( 'Products', 'woocommerce-es' );
 				?>
 					<h2>
 						<?php
 						echo sprintf(
-							esc_html__( 'Import Products from %s', 'woocommerce-es' ),
+							/* translators: %1$s: Item type (Products/Orders), %2$s: Connector name */
+							esc_html__( 'Import %1$s from %2$s', 'woocommerce-es' ),
+							esc_html( $item_type ),
 							esc_html( $this->options['name'] )
 						);
 						?>
 					</h2>
-					<p><?php esc_html_e( 'After you fillup the API settings, use the button below to import the products. The importing process may take a while and you need to keep this page open to complete it.', 'woocommerce-es' ); ?>
+					<p>
+						<?php
+						echo sprintf(
+							/* translators: %s: Item type (products/orders) */
+							esc_html__( 'After you fillup the API settings, use the button below to import the %s. The importing process may take a while and you need to keep this page open to complete it.', 'woocommerce-es' ),
+							esc_html( strtolower( $item_type ) )
+						);
+						?>
 					</p>
+					<?php if ( ! empty( $this->connectors_meta ) && count( $this->connectors_meta ) > 1 ) : ?>
+						<p>
+							<label for="connector-select"><?php esc_html_e( 'Select connector:', 'woocommerce-es' ); ?></label>
+							<select name="connwoo-connector-select" id="connector-select">
+								<?php foreach ( $this->connectors_meta as $connector_id => $meta ) : ?>
+									<?php if ( 'active' === ( $meta['status'] ?? 'active' ) ) : ?>
+										<?php
+										$connector_label = $meta['label'] ?? $connector_id;
+										$connector_type  = $meta['type'] ?? $connector_id;
+										$connector_name  = $this->connector_definitions[ $connector_type ]['name'] ?? ucfirst( $connector_type );
+										$display_text    = sprintf(
+											'%s (%s)',
+											$connector_label,
+											$connector_name
+										);
+										?>
+										<option value="<?php echo esc_attr( $connector_id ); ?>" <?php selected( $this->connector, $connector_id ); ?>>
+											<?php echo esc_html( $display_text ); ?>
+										</option>
+									<?php endif; ?>
+								<?php endforeach; ?>
+							</select>
+						</p>
+					<?php endif; ?>
 					<br/>
 					<div id="sync-products" name="sync-products" class="button button-large button-primary" onclick="syncManualItems(this, '<?php echo esc_attr( $ajax_action ); ?>', 0);" ><?php esc_html_e( 'Start Import', 'woocommerce-es' ); ?></div>
 					<?php if ( ! $this->is_disabled_ai ) { ?>
@@ -2383,29 +2418,34 @@ class Settings {
 				</div>
 			<?php endif; ?>
 			<hr/>
-			<h4><?php esc_html_e( 'Add connector', 'woocommerce-es' ); ?></h4>
 			<?php if ( empty( $this->connector_definitions ) ) : ?>
+				<h4><?php esc_html_e( 'Add connector', 'woocommerce-es' ); ?></h4>
 				<div class="notice notice-warning inline">
 					<p><?php esc_html_e( 'No connector types are available in this installation.', 'woocommerce-es' ); ?></p>
 				</div>
 			<?php else : ?>
-				<p>
-					<label for="connector-type"><?php esc_html_e( 'Connector type', 'woocommerce-es' ); ?></label><br/>
-					<select id="connector-type" name="connect_ecommerce[new_connector][type]">
-						<option value=""><?php esc_html_e( 'Select…', 'woocommerce-es' ); ?></option>
-						<?php foreach ( $this->connector_definitions as $type_key => $definition ) : ?>
-							<option value="<?php echo esc_attr( $type_key ); ?>"><?php echo esc_html( $definition['name'] ?? ucfirst( $type_key ) ); ?></option>
-						<?php endforeach; ?>
-					</select>
-				</p>
-				<p>
-					<label for="connector-label"><?php esc_html_e( 'Display name', 'woocommerce-es' ); ?></label><br/>
-					<input type="text" id="connector-label" name="connect_ecommerce[new_connector][label]" class="regular-text"/>
-				</p>
-				<p>
-					<label for="connector-custom-id"><?php esc_html_e( 'Custom identifier (optional)', 'woocommerce-es' ); ?></label><br/>
-					<input type="text" id="connector-custom-id" name="connect_ecommerce[new_connector][id]" class="regular-text" placeholder="<?php esc_attr_e( 'Auto generated when empty', 'woocommerce-es' ); ?>"/>
-				</p>
+				<div class="add-connector-wrapper">
+					<h4 class="add-connector-title"><?php esc_html_e( 'Add connector', 'woocommerce-es' ); ?></h4>
+					<div class="add-connector-row">
+						<div class="add-connector-field">
+							<label for="connector-type"><?php esc_html_e( 'Connector type', 'woocommerce-es' ); ?></label>
+							<select id="connector-type" name="connect_ecommerce[new_connector][type]">
+								<option value=""><?php esc_html_e( 'Select…', 'woocommerce-es' ); ?></option>
+								<?php foreach ( $this->connector_definitions as $type_key => $definition ) : ?>
+									<option value="<?php echo esc_attr( $type_key ); ?>"><?php echo esc_html( $definition['name'] ?? ucfirst( $type_key ) ); ?></option>
+								<?php endforeach; ?>
+							</select>
+						</div>
+						<div class="add-connector-field">
+							<label for="connector-label"><?php esc_html_e( 'Display name', 'woocommerce-es' ); ?></label>
+							<input type="text" id="connector-label" name="connect_ecommerce[new_connector][label]" class="regular-text"/>
+						</div>
+						<div class="add-connector-field">
+							<label for="connector-custom-id"><?php esc_html_e( 'Custom identifier (optional)', 'woocommerce-es' ); ?></label>
+							<input type="text" id="connector-custom-id" name="connect_ecommerce[new_connector][id]" class="regular-text" placeholder="<?php esc_attr_e( 'Auto generated when empty', 'woocommerce-es' ); ?>"/>
+						</div>
+					</div>
+				</div>
 			<?php endif; ?>
 		</div>
 		<?php

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -112,6 +112,41 @@ class Settings {
 	private $all_options;
 
 	/**
+	 * Connector type slug.
+	 *
+	 * @var string
+	 */
+	private $connector_type = '';
+
+	/**
+	 * Connector identifier.
+	 *
+	 * @var string
+	 */
+	private $connector_id = '';
+
+	/**
+	 * All configured connectors.
+	 *
+	 * @var array
+	 */
+	private $connectors = array();
+
+	/**
+	 * Connectors metadata.
+	 *
+	 * @var array
+	 */
+	private $connectors_meta = array();
+
+	/**
+	 * Workflow keys.
+	 *
+	 * @var array
+	 */
+	private $workflows = array();
+
+	/**
 	 * Settings slug
 	 *
 	 * @var string
@@ -133,21 +168,43 @@ class Settings {
 	private $payment_methods_page;
 
 	/**
+	 * Available connector definitions.
+	 *
+	 * @var array
+	 */
+	private $connector_definitions = array();
+
+	/**
 	 * Construct of class
 	 *
-	 * @param array $connector Connector.
+	 * @param array $connectors_data Connectors payload from HELPER.
 	 * @return void
 	 */
-	public function __construct( $connector ) {
-		$this->settings_all          = $connector['settings_all'];
-		$this->connector             = $connector['connector'] ?? '';
-		$this->settings              = $connector['settings'] ?? array();
-		$this->all_options           = $connector['all_options'];
-		$this->options               = $connector['options'] ?? array();
-		$this->connapi_erp           = $connector['connapi_erp'] ?? null;
-		$this->is_mergevars          = $connector['is_mergevars'] ?? false;
-		$this->is_disabled_orders    = $connector['is_disabled_orders'] ?? false;
-		$this->is_disabled_ai        = $connector['is_disabled_ai'] ?? false;
+	public function __construct( $connectors_data ) {
+		$this->settings_all    = $connectors_data['settings_all'] ?? get_option( 'connect_ecommerce' );
+		$this->connectors      = $connectors_data['items'] ?? array();
+		$this->connectors_meta = $connectors_data['meta'] ?? array();
+		$this->workflows       = array_fill_keys( HELPER::get_workflows(), true );
+
+		$this->connector_id = $connectors_data['active'] ?? '';
+		if ( empty( $this->connector_id ) && ! empty( $this->connectors ) ) {
+			$this->connector_id = array_key_first( $this->connectors );
+		}
+
+		$current_connector      = $this->connectors[ $this->connector_id ] ?? array();
+		$this->connector        = $current_connector['id'] ?? $this->connector_id;
+		$this->connector_type   = $current_connector['connector'] ?? '';
+		$this->settings         = $current_connector['settings'] ?? array();
+		$this->all_options      = $current_connector['all_options'] ?? array();
+		$this->connector_definitions = $this->all_options;
+		if ( empty( $this->connector_definitions ) && function_exists( 'conecom_get_options' ) ) {
+			$this->connector_definitions = conecom_get_options();
+		}
+		$this->options          = $current_connector['options'] ?? array();
+		$this->connapi_erp      = $current_connector['connapi_erp'] ?? null;
+		$this->is_mergevars     = $current_connector['is_mergevars'] ?? false;
+		$this->is_disabled_orders = $current_connector['is_disabled_orders'] ?? false;
+		$this->is_disabled_ai   = $current_connector['is_disabled_ai'] ?? false;
 		$this->have_payments_methods = ! empty( $this->connapi_erp ) && method_exists( $this->connapi_erp, 'get_payment_methods' );
 
 		if ( ! empty( $this->connector ) && empty( $this->options ) ) {
@@ -175,11 +232,13 @@ class Settings {
 
 		$connector_options = $this->options;
 		$connector_slug    = (string) $this->connector;
+		$connector_type    = (string) $this->connector_type;
 
 		$this->payment_methods_page = new Settings_Payment_Methods(
 			$this->connapi_erp,
 			$connector_slug,
-			is_array( $connector_options ) ? $connector_options : array()
+			is_array( $connector_options ) ? $connector_options : array(),
+			$connector_type
 		);
 	}
 
@@ -351,12 +410,21 @@ class Settings {
 						<form method="post" action="options.php">
 							<?php
 								settings_fields( 'connect_ecommerce_settings' );
-								do_settings_sections( 'connect_ecommerce_admin' );
-								submit_button(
-									__( 'Save settings', 'woocommerce-es' ),
-									'primary',
-									'submit_settings'
-								);
+								$this->render_connector_manager();
+								if ( empty( $this->connector ) ) {
+									submit_button(
+										__( 'Save connectors', 'woocommerce-es' ),
+										'primary',
+										'submit_settings'
+									);
+								} else {
+									do_settings_sections( 'connect_ecommerce_admin' );
+									submit_button(
+										__( 'Save settings', 'woocommerce-es' ),
+										'primary',
+										'submit_settings'
+									);
+								}
 							?>
 						</form>
 						<?php
@@ -1131,61 +1199,24 @@ class Settings {
 	 * @return array
 	 */
 	public function sanitize_fields_settings( $input ) {
-		$sanitary_values = array();
-		$imh_settings    = get_option( 'connect_ecommerce' );
-		$connector       = isset( $input['connector'] ) ? $input['connector'] : '';
+		$input  = is_array( $input ) ? $input : array();
+		$stored = get_option( 'connect_ecommerce' );
+		$stored = is_array( $stored ) ? $stored : array();
 
-		$admin_settings = [
-			$connector => [
-				'api'                => '',
-				'idcentre'           => '',
-				'url'                => '',
-				'username'           => '',
-				'password'           => '',
-				'company'            => '',
-				'company_id'         => '',
-				'domain'             => '',
-				'dbname'             => '',
-				'stock'              => 'no',
-				'prodst'             => 'draft',
-				'virtual'            => 'no',
-				'backorders'         => 'no',
-				'catsep'             => '',
-				'catattr'            => '',
-				'filter'             => '',
-				'pricesale_discount' => '',
-				'filter_sku'         => '',
-				'tax_option'         => 'no',
-				'rates'              => 'default',
-				'catnp'              => 'yes',
-				'doctype'            => 'invoice',
-				'cleanchars'         => '',
-				'approve_document'   => 'no',
-				'series'             => '',
-				'freeorder'          => 'no',
-				'ecstatus'           => 'all',
-				'order_tags'         => '',
-				'design_id'          => '',
-				'sync'               => 'no',
-				'sync_num'           => 5,
-				'sync_email'         => 'yes',
-				'prod_weight_eq'     => '',
-				'debug_log'          => 'no',
-			],
-		];
+		$updated = $this->sanitize_connector_manager_inputs( $input, $stored );
 
-		foreach ( $admin_settings[ $connector ] as $setting => $default_value ) {
-			if ( isset( $input[ $connector ][ $setting ] ) ) {
-				$sanitary_values[ $connector ][ $setting ] = sanitize_text_field( $input[ $connector ][ $setting ] );
-			} elseif ( isset( $imh_settings[ $connector ][ $setting ] ) ) {
-				$sanitary_values[ $connector ][ $setting ] = $imh_settings[ $connector ][ $setting ];
-			} else {
-				$sanitary_values[ $connector ][ $setting ] = $default_value;
-			}
+		$connector_id = isset( $input['connector'] ) ? sanitize_key( $input['connector'] ) : ( $updated['connector'] ?? '' );
+		if ( empty( $connector_id ) && ! empty( $updated['connectors_meta'] ) ) {
+			$connector_id = array_key_first( $updated['connectors_meta'] );
 		}
-		$sanitary_values['connector'] = $connector;
+		$updated['connector'] = $connector_id;
 
-		return $sanitary_values;
+		if ( ! empty( $connector_id ) && isset( $input[ $connector_id ] ) ) {
+			$current_settings            = $updated[ $connector_id ] ?? array();
+			$updated[ $connector_id ] = $this->sanitize_connector_settings_values( $input[ $connector_id ], $current_settings );
+		}
+
+		return $updated;
 	}
 
 	/**
@@ -1249,16 +1280,21 @@ class Settings {
 	 */
 	public function connector_callback() {
 		$connector = isset( $this->connector ) ? $this->connector : '';
+		if ( empty( $this->connectors_meta ) ) {
+			echo '<p>' . esc_html__( 'Add a connector to configure its settings.', 'woocommerce-es' ) . '</p>';
+			return;
+		}
 		?>
 		<select name="connect_ecommerce[connector]" id="wcpimh_connector" onchange="this.form.submit();">
-			<option value="" <?php selected( $connector, '' ); ?>><?php esc_html_e( 'Select the ERP/CRM that you wish to connect', 'woocommerce-es' ); ?></option>
-			<?php
-			foreach ( $this->all_options as $key => $option ) {
-				?>
-				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $connector, $key ); ?>><?php echo esc_html( $option['name'] ); ?></option>
+			<?php foreach ( $this->connectors_meta as $id => $meta ) : ?>
 				<?php
-			}
-			?>
+				$type_label = $meta['type'] ?? $id;
+				$label      = $meta['label'] ?? $type_label;
+				?>
+				<option value="<?php echo esc_attr( $id ); ?>" <?php selected( $connector, $id ); ?>>
+					<?php echo esc_html( $label . ' (' . $type_label . ')' ); ?>
+				</option>
+			<?php endforeach; ?>
 		</select>
 		<?php
 	}
@@ -2272,6 +2308,269 @@ class Settings {
 	 */
 	public function section_info_public() {
 		esc_html_e( 'Please select the following settings in order customize your eCommerce. ', 'woocommerce-es' );
+	}
+
+	/**
+	 * Outputs the connector management fields.
+	 *
+	 * @return void
+	 */
+	private function render_connector_manager() {
+		?>
+		<div class="card connector-manager">
+			<h3><?php esc_html_e( 'Connectors', 'woocommerce-es' ); ?></h3>
+			<p><?php esc_html_e( 'Manage the connectors available for this store. Only the active connector will be used for synchronisation.', 'woocommerce-es' ); ?></p>
+			<?php if ( ! empty( $this->connectors_meta ) ) : ?>
+				<table class="widefat striped">
+					<thead>
+						<tr>
+							<th><?php esc_html_e( 'ID', 'woocommerce-es' ); ?></th>
+							<th><?php esc_html_e( 'Label', 'woocommerce-es' ); ?></th>
+							<th><?php esc_html_e( 'Type', 'woocommerce-es' ); ?></th>
+							<th><?php esc_html_e( 'Workflows', 'woocommerce-es' ); ?></th>
+							<th><?php esc_html_e( 'Status', 'woocommerce-es' ); ?></th>
+							<th><?php esc_html_e( 'Remove', 'woocommerce-es' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ( $this->connectors_meta as $connector_id => $meta ) : ?>
+							<tr>
+								<td>
+									<code><?php echo esc_html( $connector_id ); ?></code>
+									<?php if ( $this->connector === $connector_id ) : ?>
+										<br/><span class="dashicons dashicons-yes"></span> <?php esc_html_e( 'Active', 'woocommerce-es' ); ?>
+									<?php endif; ?>
+								</td>
+								<td>
+									<input type="text" class="regular-text" name="connect_ecommerce[connectors_meta][<?php echo esc_attr( $connector_id ); ?>][label]" value="<?php echo esc_attr( $meta['label'] ?? '' ); ?>"/>
+									<input type="hidden" name="connect_ecommerce[connectors_meta][<?php echo esc_attr( $connector_id ); ?>][type]" value="<?php echo esc_attr( $meta['type'] ?? $connector_id ); ?>"/>
+								</td>
+								<td>
+									<?php
+									$type = $meta['type'] ?? $connector_id;
+									echo esc_html( $this->connector_definitions[ $type ]['name'] ?? ucfirst( $type ) );
+									?>
+								</td>
+								<td>
+									<?php foreach ( HELPER::get_workflows() as $workflow ) : ?>
+										<?php $enabled = isset( $meta['workflows'][ $workflow ] ) ? $meta['workflows'][ $workflow ] : 'yes'; ?>
+										<label style="display:block;">
+											<input type="hidden" name="connect_ecommerce[connectors_meta][<?php echo esc_attr( $connector_id ); ?>][workflows][<?php echo esc_attr( $workflow ); ?>]" value="no"/>
+											<input type="checkbox" name="connect_ecommerce[connectors_meta][<?php echo esc_attr( $connector_id ); ?>][workflows][<?php echo esc_attr( $workflow ); ?>]" value="yes" <?php checked( 'yes', $enabled ); ?>/>
+											<?php echo esc_html( $this->get_workflow_label( $workflow ) ); ?>
+										</label>
+									<?php endforeach; ?>
+								</td>
+								<td>
+									<select name="connect_ecommerce[connectors_meta][<?php echo esc_attr( $connector_id ); ?>][status]">
+										<option value="active" <?php selected( 'active', $meta['status'] ?? 'active' ); ?>><?php esc_html_e( 'Active', 'woocommerce-es' ); ?></option>
+										<option value="inactive" <?php selected( 'inactive', $meta['status'] ?? 'active' ); ?>><?php esc_html_e( 'Inactive', 'woocommerce-es' ); ?></option>
+									</select>
+								</td>
+								<td>
+									<label>
+										<input type="checkbox" name="connect_ecommerce[remove_connectors][]" value="<?php echo esc_attr( $connector_id ); ?>"/>
+										<?php esc_html_e( 'Remove', 'woocommerce-es' ); ?>
+									</label>
+								</td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+			<?php else : ?>
+				<div class="notice notice-info inline">
+					<p><?php esc_html_e( 'No connectors have been configured yet.', 'woocommerce-es' ); ?></p>
+				</div>
+			<?php endif; ?>
+			<hr/>
+			<h4><?php esc_html_e( 'Add connector', 'woocommerce-es' ); ?></h4>
+			<?php if ( empty( $this->connector_definitions ) ) : ?>
+				<div class="notice notice-warning inline">
+					<p><?php esc_html_e( 'No connector types are available in this installation.', 'woocommerce-es' ); ?></p>
+				</div>
+			<?php else : ?>
+				<p>
+					<label for="connector-type"><?php esc_html_e( 'Connector type', 'woocommerce-es' ); ?></label><br/>
+					<select id="connector-type" name="connect_ecommerce[new_connector][type]">
+						<option value=""><?php esc_html_e( 'Select…', 'woocommerce-es' ); ?></option>
+						<?php foreach ( $this->connector_definitions as $type_key => $definition ) : ?>
+							<option value="<?php echo esc_attr( $type_key ); ?>"><?php echo esc_html( $definition['name'] ?? ucfirst( $type_key ) ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</p>
+				<p>
+					<label for="connector-label"><?php esc_html_e( 'Display name', 'woocommerce-es' ); ?></label><br/>
+					<input type="text" id="connector-label" name="connect_ecommerce[new_connector][label]" class="regular-text"/>
+				</p>
+				<p>
+					<label for="connector-custom-id"><?php esc_html_e( 'Custom identifier (optional)', 'woocommerce-es' ); ?></label><br/>
+					<input type="text" id="connector-custom-id" name="connect_ecommerce[new_connector][id]" class="regular-text" placeholder="<?php esc_attr_e( 'Auto generated when empty', 'woocommerce-es' ); ?>"/>
+				</p>
+			<?php endif; ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Returns a translated workflow label.
+	 *
+	 * @param string $workflow Workflow key.
+	 * @return string
+	 */
+	private function get_workflow_label( $workflow ) {
+		switch ( $workflow ) {
+			case 'orders':
+				return __( 'Orders', 'woocommerce-es' );
+			case 'products':
+				return __( 'Products', 'woocommerce-es' );
+			default:
+				return ucfirst( $workflow );
+		}
+	}
+
+	/**
+	 * Sanitize connector metadata and handle add/remove operations.
+	 *
+	 * @param array $input  Raw input.
+	 * @param array $stored Stored settings.
+	 * @return array
+	 */
+	private function sanitize_connector_manager_inputs( array $input, array $stored ) {
+		$meta = $stored['connectors_meta'] ?? array();
+
+		if ( ! empty( $input['remove_connectors'] ) && is_array( $input['remove_connectors'] ) ) {
+			foreach ( $input['remove_connectors'] as $remove_id ) {
+				$remove_id = sanitize_key( $remove_id );
+				if ( empty( $remove_id ) ) {
+					continue;
+				}
+				unset( $meta[ $remove_id ], $stored[ $remove_id ] );
+				if ( isset( $stored['connector'] ) && $stored['connector'] === $remove_id ) {
+					$stored['connector'] = '';
+				}
+			}
+		}
+
+		if ( isset( $input['connectors_meta'] ) && is_array( $input['connectors_meta'] ) ) {
+			foreach ( $input['connectors_meta'] as $connector_id => $meta_input ) {
+				$connector_id = sanitize_key( $connector_id );
+				if ( empty( $connector_id ) || ! isset( $meta[ $connector_id ] ) ) {
+					continue;
+				}
+
+				$meta[ $connector_id ]['label']  = sanitize_text_field( $meta_input['label'] ?? $meta[ $connector_id ]['label'] );
+				$meta[ $connector_id ]['status'] = isset( $meta_input['status'] ) && 'inactive' === $meta_input['status'] ? 'inactive' : 'active';
+
+				foreach ( HELPER::get_workflows() as $workflow ) {
+					$value = isset( $meta_input['workflows'][ $workflow ] ) && 'yes' === $meta_input['workflows'][ $workflow ] ? 'yes' : 'no';
+					$meta[ $connector_id ]['workflows'][ $workflow ] = $value;
+				}
+			}
+		}
+
+		if ( ! empty( $input['new_connector'] ) && is_array( $input['new_connector'] ) ) {
+			$type  = sanitize_key( $input['new_connector']['type'] ?? '' );
+			$label = sanitize_text_field( $input['new_connector']['label'] ?? '' );
+			$custom_id = sanitize_key( $input['new_connector']['id'] ?? '' );
+
+			if ( $type && isset( $this->connector_definitions[ $type ] ) ) {
+				$new_id = $custom_id ?: sanitize_key( $type . '-' . $label );
+				if ( empty( $new_id ) || isset( $meta[ $new_id ] ) ) {
+					$new_id = sanitize_key( $type . '-' . uniqid() );
+				}
+
+				$meta[ $new_id ] = array(
+					'type'      => $type,
+					'label'     => $label ?: ( $this->connector_definitions[ $type ]['name'] ?? ucfirst( $type ) ),
+					'status'    => 'active',
+					'workflows' => array(),
+				);
+
+				foreach ( HELPER::get_workflows() as $workflow ) {
+					$meta[ $new_id ]['workflows'][ $workflow ] = 'yes';
+				}
+
+				$stored[ $new_id ] = isset( $stored[ $new_id ] ) ? $stored[ $new_id ] : array();
+				$stored['connector'] = $new_id;
+			}
+		}
+
+		$stored['connectors_meta'] = $meta;
+
+		if ( ! empty( $stored['connector'] ) && ! isset( $meta[ $stored['connector'] ] ) ) {
+			$stored['connector'] = '';
+		}
+		if ( empty( $stored['connector'] ) && ! empty( $meta ) ) {
+			$stored['connector'] = array_key_first( $meta );
+		}
+
+		return $stored;
+	}
+
+	/**
+	 * Sanitize connector-specific settings.
+	 *
+	 * @param array $input    Connector input.
+	 * @param array $existing Existing values.
+	 * @return array
+	 */
+	private function sanitize_connector_settings_values( array $input, array $existing ) {
+		$defaults = $this->get_connector_default_settings();
+		$sanitized = $existing;
+
+		foreach ( $defaults as $key => $default_value ) {
+			if ( isset( $input[ $key ] ) ) {
+				$sanitized[ $key ] = sanitize_text_field( $input[ $key ] );
+			} elseif ( ! isset( $sanitized[ $key ] ) ) {
+				$sanitized[ $key ] = $default_value;
+			}
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Default settings for a connector block.
+	 *
+	 * @return array
+	 */
+	private function get_connector_default_settings() {
+		return array(
+			'api'                => '',
+			'idcentre'           => '',
+			'url'                => '',
+			'username'           => '',
+			'password'           => '',
+			'company'            => '',
+			'company_id'         => '',
+			'domain'             => '',
+			'dbname'             => '',
+			'stock'              => 'no',
+			'prodst'             => 'draft',
+			'virtual'            => 'no',
+			'backorders'         => 'no',
+			'catsep'             => '',
+			'catattr'            => '',
+			'filter'             => '',
+			'pricesale_discount' => '',
+			'filter_sku'         => '',
+			'tax_option'         => 'no',
+			'rates'              => 'default',
+			'catnp'              => 'yes',
+			'doctype'            => 'invoice',
+			'cleanchars'         => '',
+			'approve_document'   => 'no',
+			'series'             => '',
+			'freeorder'          => 'no',
+			'ecstatus'           => 'all',
+			'order_tags'         => '',
+			'design_id'          => '',
+			'sync'               => 'no',
+			'sync_num'           => 5,
+			'sync_email'         => 'yes',
+			'prod_weight_eq'     => '',
+			'debug_log'          => 'no',
+		);
 	}
 
 	/**

--- a/includes/Admin/Settings_Payment_Methods.php
+++ b/includes/Admin/Settings_Payment_Methods.php
@@ -44,18 +44,27 @@ class Settings_Payment_Methods {
 	private $connector_options = array();
 
 	/**
+	 * Connector type slug.
+	 *
+	 * @var string
+	 */
+	private $connector_type = '';
+
+	/**
 	 * Construct of class.
 	 *
 	 * @param object|null $connector_api Connector API instance.
-	 * @param string      $connector_slug Connector slug.
+	 * @param string      $connector_slug Connector identifier.
 	 * @param array       $connector_options Connector specific options.
+	 * @param string      $connector_type Connector type slug.
 	 *
 	 * @return void
 	 */
-	public function __construct( $connector_api = null, $connector_slug = '', $connector_options = array() ) {
+	public function __construct( $connector_api = null, $connector_slug = '', $connector_options = array(), $connector_type = '' ) {
 		$this->connector_api     = $connector_api;
 		$this->connector_slug    = $connector_slug;
 		$this->connector_options = $connector_options;
+		$this->connector_type    = $connector_type;
 
 		add_action( 'admin_post_connect_ecommerce_save_payment_methods', array( $this, 'handle_form_submission' ) );
 	}
@@ -452,7 +461,7 @@ class Settings_Payment_Methods {
 	 * @return array
 	 */
 	private function get_saved_mappings() {
-		$mappings = PAYMENTS::get_payment_method_mappings( $this->connector_slug );
+		$mappings = PAYMENTS::get_payment_method_mappings( $this->connector_slug, $this->connector_type );
 
 		// Convert to the format expected by render_page.
 		$prepared = array();

--- a/includes/Connector/class-api-clientify.php
+++ b/includes/Connector/class-api-clientify.php
@@ -33,13 +33,28 @@ class Connect_Ecommerce_Clientify {
 	private $options;
 
 	/**
+	 * Connector instance identifier.
+	 *
+	 * @var string
+	 */
+	private $connector_id = 'clientify';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param array $options Options of plugin.
 	 */
-	public function __construct( $options ) {
-		$this->options  = $options['clientify'];
-		$this->settings = get_option( 'connect_ecommerce' )['clientify'] ?? array();
+	public function __construct( $options, $connector_id = null ) {
+		$this->options      = $options['clientify'];
+		$this->connector_id = $connector_id ?: 'clientify';
+
+		$settings_all   = get_option( 'connect_ecommerce' );
+		$connector_key  = $this->connector_id;
+		if ( isset( $settings_all[ $connector_key ] ) ) {
+			$this->settings = $settings_all[ $connector_key ];
+		} else {
+			$this->settings = $settings_all['clientify'] ?? array();
+		}
 
 		add_filter( 'woocommerce_checkout_fields', array( $this, 'clientify_cookie_checkout_field' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );

--- a/includes/Helpers/HELPER.php
+++ b/includes/Helpers/HELPER.php
@@ -21,6 +21,13 @@ defined( 'ABSPATH' ) || exit;
  */
 class HELPER {
 	/**
+	 * Default workflows supported by the plugin.
+	 *
+	 * @var array
+	 */
+	private static $default_workflows = array( 'products', 'orders' );
+
+	/**
 	 * Emails products with errors
 	 *
 	 * @param array  $product_errors Array of errors.
@@ -216,51 +223,220 @@ class HELPER {
 	}
 
 	/**
-	 * Get connector of plugin.
+	 * Retrieves the list of workflows supported by connectors.
+	 *
+	 * @return array
+	 */
+	public static function get_workflows() {
+		return self::$default_workflows;
+	}
+
+	/**
+	 * Get connector of plugin (legacy helper).
 	 *
 	 * @param array $options Options of plugin.
 	 * @return array
 	 */
 	public static function get_connector( $options ) {
-		$connector                 = array();
-		$connector['settings_all'] = get_option( 'connect_ecommerce' );
-		$connector['connector']    = isset( $connector['settings_all']['connector'] ) ? $connector['settings_all']['connector'] : '';
-		$connector['settings']     = $connector['settings_all'][ $connector['connector'] ] ?? array();
-		$connector['all_options']  = $options;
+		$connectors_data = self::get_connectors( $options );
+		$connectors      = $connectors_data['items'];
 
-		$connector['settings']['prod_mergevars'] = get_option( 'connect_ecommerce_prod_mergevars' )['prod_mergevars'] ?? array();
-
-		// Initialize payment method mappings.
-		$connector['settings']['payment_methods']   = array();
-		$connector['settings']['treasury_accounts'] = array();
-
-		if ( ! empty( $connector['connector'] ) ) {
-			// Get payment method mappings.
-			$payment_mappings                           = PAYMENTS::get_payment_method_mappings( $connector['connector'] );
-			$connector['settings']['payment_methods']   = $payment_mappings['payment_methods'];
-			$connector['settings']['treasury_accounts'] = $payment_mappings['treasury_accounts'];
-
-			if ( ! isset( $options[ $connector['connector'] ] ) ) {
-				return $connector;
-			}
-
-			$connector['options'] = $options[ $connector['connector'] ];
-			if ( empty( $connector['options']['name'] ) ) {
-				$connector['settings_all']['connector'] = '';
-				update_option( 'connect_ecommerce', $connector['settings_all'] );
-				return $connector;
-			}
-			$apiname = 'Connect_Ecommerce_' . $connector['options']['name'];
-
-			if ( ! class_exists( $apiname ) ) {
-				return $connector;
-			}
-			$connector['connapi_erp']        = new $apiname( $options );
-			$connector['is_mergevars']       = method_exists( $connector['connapi_erp'], 'get_product_attributes' ) ? true : false;
-			$connector['is_disabled_orders'] = isset( $connector['options']['disable_modules'] ) && in_array( 'order', $connector['options']['disable_modules'], true ) ? true : false;
-			$connector['is_disabled_ai']     = isset( $connector['options']['disable_modules'] ) && in_array( 'ai', $connector['options']['disable_modules'], true ) ? true : false;
+		if ( empty( $connectors ) ) {
+			return array(
+				'id'           => '',
+				'connector'    => '',
+				'settings_all' => $connectors_data['settings_all'],
+				'settings'     => array(
+					'prod_mergevars'    => get_option( 'connect_ecommerce_prod_mergevars' )['prod_mergevars'] ?? array(),
+					'payment_methods'   => array(),
+					'treasury_accounts' => array(),
+				),
+				'all_options'  => $options,
+			);
 		}
 
+		$active_id = $connectors_data['active'];
+		if ( empty( $active_id ) || ! isset( $connectors[ $active_id ] ) ) {
+			$active_id = array_key_first( $connectors );
+		}
+
+		return $connectors[ $active_id ];
+	}
+
+	/**
+	 * Returns every connector context configured in the site.
+	 *
+	 * @param array $options Connector definitions.
+	 * @return array
+	 */
+	public static function get_connectors( $options ) {
+		$settings_all = get_option( 'connect_ecommerce', array() );
+		$normalized   = self::normalize_connectors_structure( $settings_all, $options );
+
+		if ( $normalized['dirty'] ) {
+			update_option( 'connect_ecommerce', $normalized['settings_all'] );
+		}
+
+		$connectors    = array();
+		$meta          = $normalized['connectors_meta'];
+		$active        = $normalized['active_connector'];
+		$prod_mergevar = get_option( 'connect_ecommerce_prod_mergevars' )['prod_mergevars'] ?? array();
+
+		foreach ( $meta as $connector_id => $connector_meta ) {
+			$connectors[ $connector_id ] = self::build_connector_context(
+				$connector_id,
+				$connector_meta,
+				$options,
+				$normalized['settings_all'],
+				$prod_mergevar
+			);
+		}
+
+		return array(
+			'items'        => $connectors,
+			'active'       => $active,
+			'settings_all' => $normalized['settings_all'],
+			'meta'         => $meta,
+		);
+	}
+
+	/**
+	 * Normalize connectors setup to the new structure.
+	 *
+	 * @param array $settings_all Raw option value.
+	 * @param array $options Connector definitions.
+	 * @return array
+	 */
+	private static function normalize_connectors_structure( $settings_all, $options ) {
+		$settings_all   = is_array( $settings_all ) ? $settings_all : array();
+		$connectors_meta = $settings_all['connectors_meta'] ?? array();
+		$dirty           = false;
+
+		if ( empty( $connectors_meta ) ) {
+			$legacy_connector = isset( $settings_all['connector'] ) ? $settings_all['connector'] : '';
+			if ( $legacy_connector && isset( $settings_all[ $legacy_connector ] ) ) {
+				$connectors_meta[ $legacy_connector ] = array(
+					'type'      => $legacy_connector,
+					'label'     => $options[ $legacy_connector ]['name'] ?? ucfirst( $legacy_connector ),
+					'workflows' => array(
+						'products' => 'yes',
+						'orders'   => 'yes',
+					),
+					'status'    => 'active',
+				);
+				$dirty = true;
+			}
+		}
+
+		// Ensure every connector meta entry has defaults.
+		foreach ( $connectors_meta as $connector_id => $meta ) {
+			$new_meta = array(
+				'type'      => $meta['type'] ?? $connector_id,
+				'label'     => $meta['label'] ?? ( $options[ $meta['type'] ?? $connector_id ]['name'] ?? $connector_id ),
+				'workflows' => $meta['workflows'] ?? array(),
+				'status'    => $meta['status'] ?? 'active',
+			);
+
+			foreach ( self::$default_workflows as $workflow ) {
+				if ( ! isset( $new_meta['workflows'][ $workflow ] ) ) {
+					$new_meta['workflows'][ $workflow ] = 'yes';
+				}
+			}
+
+			if ( $new_meta !== $meta ) {
+				$connectors_meta[ $connector_id ] = $new_meta;
+				$dirty                            = true;
+			}
+		}
+
+		$settings_all['connectors_meta'] = $connectors_meta;
+
+		if ( empty( $settings_all['connector'] ) && ! empty( $connectors_meta ) ) {
+			$settings_all['connector'] = array_key_first( $connectors_meta );
+			$dirty                     = true;
+		}
+
+		return array(
+			'settings_all'    => $settings_all,
+			'connectors_meta' => $connectors_meta,
+			'active_connector'=> $settings_all['connector'] ?? '',
+			'dirty'           => $dirty,
+		);
+	}
+
+	/**
+	 * Build connector context consumed across the plugin.
+	 *
+	 * @param string $connector_id Connector identifier.
+	 * @param array  $meta         Metadata for connector.
+	 * @param array  $options      Connector definitions.
+	 * @param array  $settings_all Raw settings option.
+	 * @param array  $prod_mergevar Merge vars settings.
+	 * @return array
+	 */
+	private static function build_connector_context( $connector_id, $meta, $options, $settings_all, $prod_mergevar ) {
+		$connector_type   = $meta['type'] ?? $connector_id;
+		$connector_options = $options[ $connector_type ] ?? array();
+		$connector         = array(
+			'id'            => $connector_id,
+			'connector'     => $connector_type,
+			'meta'          => $meta,
+			'settings_all'  => $settings_all,
+			'settings'      => $settings_all[ $connector_id ] ?? array(),
+			'all_options'   => $options,
+		);
+
+		$connector['settings']['prod_mergevars']    = $prod_mergevar;
+		$connector['settings']['payment_methods']   = array();
+		$connector['settings']['treasury_accounts'] = array();
+		$connector['is_disabled_orders']            = false;
+		$connector['is_disabled_ai']                = false;
+		$connector['is_mergevars']                  = false;
+
+		$payment_mappings = PAYMENTS::get_payment_method_mappings( $connector_id, $connector_type );
+		$connector['settings']['payment_methods']   = $payment_mappings['payment_methods'];
+		$connector['settings']['treasury_accounts'] = $payment_mappings['treasury_accounts'];
+
+		if ( empty( $connector_options ) || empty( $connector_options['name'] ) ) {
+			$connector['actions'] = array(
+				'sync_products' => self::get_connector_action_name( 'connect_ecommerce_sync_products', $connector_id ),
+				'sync_orders'   => self::get_connector_action_name( 'connect_ecommerce_sync_orders', $connector_id ),
+				'single_order'  => self::get_connector_action_name( 'sync_erp_order', $connector_id ),
+			);
+			return $connector;
+		}
+
+		$connector['options']          = $connector_options;
+		$apiname                       = 'Connect_Ecommerce_' . $connector_options['name'];
+		$connector['is_disabled_orders'] = isset( $connector_options['disable_modules'] ) && in_array( 'order', $connector_options['disable_modules'], true );
+		$connector['is_disabled_ai']     = isset( $connector_options['disable_modules'] ) && in_array( 'ai', $connector_options['disable_modules'], true );
+
+		if ( class_exists( $apiname ) ) {
+			$connector['connapi_erp']  = new $apiname( $options, $connector_id );
+			$connector['is_mergevars'] = method_exists( $connector['connapi_erp'], 'get_product_attributes' );
+		}
+
+		$connector['actions'] = array(
+			'sync_products' => self::get_connector_action_name( 'connect_ecommerce_sync_products', $connector_id ),
+			'sync_orders'   => self::get_connector_action_name( 'connect_ecommerce_sync_orders', $connector_id ),
+			'single_order'  => self::get_connector_action_name( 'sync_erp_order', $connector_id ),
+		);
+
 		return $connector;
+	}
+
+	/**
+	 * Generates a sanitized action name for a connector.
+	 *
+	 * @param string $base_action Base action name.
+	 * @param string $connector_id Connector identifier.
+	 * @return string
+	 */
+	public static function get_connector_action_name( $base_action, $connector_id ) {
+		$connector_id = sanitize_key( $connector_id );
+		if ( empty( $connector_id ) ) {
+			return sanitize_key( $base_action );
+		}
+		return sanitize_key( $base_action . '_' . $connector_id );
 	}
 }

--- a/includes/Helpers/HELPER.php
+++ b/includes/Helpers/HELPER.php
@@ -264,6 +264,24 @@ class HELPER {
 	}
 
 	/**
+	 * Returns a specific connector by ID.
+	 *
+	 * @param string $connector_id Connector ID.
+	 * @param array  $options Connector definitions.
+	 * @return array|null Connector data or null if not found.
+	 */
+	public static function get_connector_by_id( $connector_id, $options ) {
+		$connectors_data = self::get_connectors( $options );
+		$connectors      = $connectors_data['items'];
+
+		if ( ! isset( $connectors[ $connector_id ] ) ) {
+			return null;
+		}
+
+		return $connectors[ $connector_id ];
+	}
+
+	/**
 	 * Returns every connector context configured in the site.
 	 *
 	 * @param array $options Connector definitions.

--- a/includes/Helpers/PAYMENTS.php
+++ b/includes/Helpers/PAYMENTS.php
@@ -28,10 +28,11 @@ class PAYMENTS {
 	/**
 	 * Get payment method mappings for a connector.
 	 *
-	 * @param string $connector_slug Connector slug.
+	 * @param string $connector_slug Connector identifier.
+	 * @param string $fallback_slug  Optional fallback slug (legacy).
 	 * @return array Array with 'payment_methods' and 'treasury_accounts' keys.
 	 */
-	public static function get_payment_method_mappings( $connector_slug ) {
+	public static function get_payment_method_mappings( $connector_slug, $fallback_slug = '' ) {
 		if ( '' === $connector_slug ) {
 			return array(
 				'payment_methods'   => array(),
@@ -48,7 +49,12 @@ class PAYMENTS {
 			);
 		}
 
-		if ( ! isset( $stored[ $connector_slug ] ) || ! is_array( $stored[ $connector_slug ] ) ) {
+		$lookup_slug = $connector_slug;
+		if ( ! isset( $stored[ $lookup_slug ] ) && $fallback_slug && isset( $stored[ $fallback_slug ] ) ) {
+			$lookup_slug = $fallback_slug;
+		}
+
+		if ( ! isset( $stored[ $lookup_slug ] ) || ! is_array( $stored[ $lookup_slug ] ) ) {
 			return array(
 				'payment_methods'   => array(),
 				'treasury_accounts' => array(),
@@ -58,7 +64,7 @@ class PAYMENTS {
 		$payment_methods    = array();
 		$treasury_accounts  = array();
 
-		foreach ( $stored[ $connector_slug ] as $gateway_id => $mapping ) {
+		foreach ( $stored[ $lookup_slug ] as $gateway_id => $mapping ) {
 			if ( ! is_scalar( $gateway_id ) ) {
 				continue;
 			}
@@ -103,12 +109,12 @@ class PAYMENTS {
 	 * @param string $connector_slug Connector slug.
 	 * @return string Payment method ID or empty string.
 	 */
-	public static function get_payment_method_id( $gateway_id, $connector_slug ) {
+	public static function get_payment_method_id( $gateway_id, $connector_slug, $fallback_slug = '' ) {
 		if ( '' === $gateway_id || '' === $connector_slug ) {
 			return '';
 		}
 
-		$mappings = self::get_payment_method_mappings( $connector_slug );
+		$mappings = self::get_payment_method_mappings( $connector_slug, $fallback_slug );
 		return isset( $mappings['payment_methods'][ $gateway_id ] )
 			? $mappings['payment_methods'][ $gateway_id ]
 			: '';
@@ -121,12 +127,12 @@ class PAYMENTS {
 	 * @param string $connector_slug Connector slug.
 	 * @return string Treasury account ID or empty string.
 	 */
-	public static function get_treasury_account_id( $gateway_id, $connector_slug ) {
+	public static function get_treasury_account_id( $gateway_id, $connector_slug, $fallback_slug = '' ) {
 		if ( '' === $gateway_id || '' === $connector_slug ) {
 			return '';
 		}
 
-		$mappings = self::get_payment_method_mappings( $connector_slug );
+		$mappings = self::get_payment_method_mappings( $connector_slug, $fallback_slug );
 		return isset( $mappings['treasury_accounts'][ $gateway_id ] )
 			? $mappings['treasury_accounts'][ $gateway_id ]
 			: '';

--- a/includes/Plugin_Main.php
+++ b/includes/Plugin_Main.php
@@ -36,7 +36,7 @@ class Base {
 	 *
 	 * @var array
 	 */
-	private $options = array();
+	private $options  = array();
 
 	/**
 	 * Construct of class
@@ -44,11 +44,12 @@ class Base {
 	 * @param array $options Options of plugin.
 	 */
 	public function __construct( $options = array() ) {
-		$this->options = $options;
-		$connector     = HELPER::get_connector( $options );
+		$this->options        = $options;
+		$connectors_data      = HELPER::get_connectors( $options );
+		$connector            = HELPER::get_connector( $options );
 
 		if ( is_admin() ) {
-			new Settings( $connector );
+			new Settings( $connectors_data );
 			new Import_Products( $connector );
 			new Widget_Product( $connector );
 			new Widget_Order( $connector );
@@ -70,4 +71,5 @@ class Base {
 	public function get_options() {
 		return $this->options;
 	}
+
 }

--- a/includes/assets/admin.css
+++ b/includes/assets/admin.css
@@ -160,3 +160,50 @@
 	width: 85%;
 	margin: 10px;
 }
+
+/* Connector Manager */
+.connect-ecommerce-settings .card.connector-manager {
+	max-width: 100%;
+}
+
+.connect-ecommerce-settings .connector-manager table.widefat {
+	width: 100%;
+}
+
+.connect-ecommerce-settings .add-connector-wrapper {
+	display: flex;
+	align-items: flex-end;
+	gap: 20px;
+	flex-wrap: wrap;
+}
+
+.connect-ecommerce-settings .add-connector-title {
+	margin: 0 0 8px 0;
+	flex-shrink: 0;
+	align-self: flex-start;
+	padding-top: 8px;
+}
+
+.connect-ecommerce-settings .add-connector-row {
+	display: flex;
+	gap: 20px;
+	align-items: flex-end;
+	flex-wrap: wrap;
+	flex: 1;
+}
+
+.connect-ecommerce-settings .add-connector-field {
+	flex: 1;
+	min-width: 200px;
+}
+
+.connect-ecommerce-settings .add-connector-field label {
+	display: block;
+	margin-bottom: 5px;
+	font-weight: 600;
+}
+
+.connect-ecommerce-settings .add-connector-field select,
+.connect-ecommerce-settings .add-connector-field input[type="text"] {
+	width: 100%;
+}

--- a/includes/assets/sync-import.js
+++ b/includes/assets/sync-import.js
@@ -2,6 +2,7 @@ function syncManualItems( element, action, loop = 0 ) {
 	element.classList.add('disabled');
 	element.innerHTML = ConEcom_ajaxAction.label_syncing + ' <span class="spinner is-active"></span>';
 	const productAI = document.querySelector('select[name="connwoo-sync-product-ai"]')?.value || '';
+	const connectorId = document.querySelector('select[name="connwoo-connector-select"]')?.value || '';
 
 	const isOdd = number => number % 2 !== 0;
 	class_task = isOdd(loop) ? 'odd' : 'even';
@@ -14,7 +15,7 @@ function syncManualItems( element, action, loop = 0 ) {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			'Cache-Control': 'no-cache',
 		},
-		body: 'action=' + action + '&nonce=' + ConEcom_ajaxAction.nonce + '&loop=' + loop + '&product_ai=' + productAI,
+		body: 'action=' + action + '&nonce=' + ConEcom_ajaxAction.nonce + '&loop=' + loop + '&product_ai=' + productAI + '&connector_id=' + connectorId,
 	})
 	.then( (resp) => resp.json() )
 	.then( function(results) {


### PR DESCRIPTION
Enable multi-connector support in the Connect Ecommerce plugin to allow stores to integrate with multiple external services.

The plugin previously only supported a single ERP/CRM connection. This PR introduces a new UI and underlying data structure to manage multiple connector instances, each with its own settings, workflows, and status, addressing the limitation for stores requiring diverse integrations. It also includes a migration path for existing single-connector setups and developer documentation for registering custom connector types.

---
<a href="https://cursor.com/background-agent?bcId=bc-974961f5-47ee-4892-af17-a1ff791d7e2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-974961f5-47ee-4892-af17-a1ff791d7e2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

