### PR TITLE
show status

### DIFF
--- a/includes/Admin/Settings_Payment_Methods.php
+++ b/includes/Admin/Settings_Payment_Methods.php
@@ -140,6 +140,7 @@ class Settings_Payment_Methods {
 					<thead>
 						<tr>
 							<th scope="col"><?php esc_html_e( 'WooCommerce Gateway', 'woocommerce-es' ); ?></th>
+							<th scope="col"><?php esc_html_e( 'Status', 'woocommerce-es' ); ?></th>
 							<th scope="col"><?php esc_html_e( 'Connector Payment Method', 'woocommerce-es' ); ?></th>
 							<th scope="col"><?php esc_html_e( 'Connector Treasury', 'woocommerce-es' ); ?></th>
 						</tr>
@@ -194,6 +195,16 @@ class Settings_Payment_Methods {
 									<strong><?php echo esc_html( $gateway_title ); ?></strong>
 									<br />
 									<code><?php echo esc_html( $sanitized_gateway_id ); ?></code>
+								</td>
+								<td>
+									<?php
+									$is_enabled = isset( $gateway->enabled ) && 'yes' === $gateway->enabled;
+									if ( $is_enabled ) {
+										echo '<span class="status-enabled" style="color: #2271b1; font-weight: 600;">' . esc_html__( 'Active', 'woocommerce-es' ) . '</span>';
+									} else {
+										echo '<span class="status-disabled" style="color: #d63638; font-weight: 600;">' . esc_html__( 'Inactive', 'woocommerce-es' ) . '</span>';
+									}
+									?>
 								</td>
 								<td>
 									<select name="payment_methods[<?php echo esc_attr( $sanitized_gateway_id ); ?>]" class="regular-text">
@@ -366,6 +377,21 @@ class Settings_Payment_Methods {
 		if ( ! is_array( $gateways ) ) {
 			return array();
 		}
+
+		// Sort gateways: active first.
+		uasort(
+			$gateways,
+			function ( $a, $b ) {
+				$a_enabled = isset( $a->enabled ) && 'yes' === $a->enabled ? 1 : 0;
+				$b_enabled = isset( $b->enabled ) && 'yes' === $b->enabled ? 1 : 0;
+
+				if ( $a_enabled === $b_enabled ) {
+					return 0;
+				}
+
+				return ( $a_enabled > $b_enabled ) ? -1 : 1;
+			}
+		);
 
 		return $gateways;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -219,6 +219,7 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 == Changelog ==
 
 = n.e.x.t =
+* Enhancement: Added payment method status to payment method mapping.
 * Fixed: Variations now inherit parent tax class correctly by setting tax_class to "parent" on creation.
 * Fixed: Tax class "parent" is preserved when products are re-synced/updated, preventing tax calculation inconsistencies.
 * Fixed: Product importer now correctly detects end of paginated product list, preventing unnecessary API calls beyond last product.


### PR DESCRIPTION
This PR improves the usability of the Payment Method Mapping settings page by providing visual feedback on the activation status of WooCommerce gateways and sorting them logically.

Fixes #122

## Changes

- **Added Status Column**: A new column has been added to the mapping table to show if a gateway is "Active" or "Inactive".
- **Visual Indicators**: Statuses are color-coded (Blue for Active, Red for Inactive) following WordPress/WooCommerce UI conventions.
- **Improved Sorting**: Gateways are now automatically sorted so that active payment methods appear at the top of the list, followed by inactive ones.

## Benefits

- Store administrators can quickly identify which gateways need mapping.
- Reduces configuration errors by highlighting active vs. inactive methods.
- More intuitive layout for stores with many installed payment gateways.

## Testing Instructions

1. Navigate to **Connect Ecommerce > Settings > Payment Methods**.
2. Verify that a new **Status** column is visible.
3. Check that active gateways show a blue "Active" label and inactive ones show a red "Inactive" label.
4. Verify that the list is ordered with all "Active" gateways appearing before "Inactive" ones.
5. Save the mappings to ensure form submission still works correctly.