### PR TITLE
Fix: Import custom fields using source key fallback

### DIFF
--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -418,6 +418,8 @@ class PROD {
 				$field_slug = isset( $field_key[1] ) ? $field_key[1] : $field_key;
 				if ( isset( $item[ $custom_field ] ) && 'cf' === $field_type ) {
 					$product->update_meta_data( $field_slug, $item[ $custom_field ] );
+				} elseif ( isset( $item[ $source_key ] ) && 'cf' === $field_type ) {
+					$product->update_meta_data( $field_slug, $item[ $source_key ] );
 				} elseif ( isset( $item[ $custom_field ] ) && 'tax' === $field_type ) {
 					TAX::set_terms_taxonomy( $settings, $field_slug, $item[ $custom_field ], $product_id );
 				} elseif ( isset( $item[ $custom_field ] ) && 'prod' === $field_type ) {

--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,7 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 * Fixed: Product importer now correctly detects end of paginated product list, preventing unnecessary API calls beyond last product.
 * Enhancement: Added comprehensive test coverage for variation tax class inheritance and persistence on updates.
 * Enhancement: Added pagination end detection tests for product import with various edge cases (102/100, exact pages, multiple pages).
+* Enhancement: Added support to import custom fields from API to WooCommerce.
 
 = 3.3.2 =
 * Added: Support to FacturaDirecta connector.


### PR DESCRIPTION
# Description

This PR fixes an issue where custom fields were not being imported from the API when the API response uses the source key directly instead of the mapped custom field name. The fix adds a fallback mechanism to check for the source key when the custom field key is not available in the API response.

## Changes

- **Fixed custom field import logic**: Added fallback check in `includes/Helpers/PROD.php` to use `$source_key` when `$custom_field` is not present in the API response item
- **Updated changelog**: Added entry in `readme.txt` documenting the enhancement for custom field import support

## Technical Details

The product import process maps API fields to WooCommerce custom fields through `prod_mergevars` settings. Previously, the code only checked for the mapped custom field name (`$custom_field`) in the API response. Now it also checks for the original source key (`$source_key`) as a fallback, ensuring custom fields are imported even when the API response structure doesn't match the expected mapped field name.

**Code change location**: `includes/Helpers/PROD.php` lines 421-422

```php
} elseif ( isset( $item[ $source_key ] ) && 'cf' === $field_type ) {
    $product->update_meta_data( $field_slug, $item[ $source_key ] );
```

## Benefits

- **Improved reliability**: Custom fields are now imported successfully even when API responses use source keys instead of mapped field names
- **Better compatibility**: Works with APIs that return data using original field names rather than mapped custom field names
- **No breaking changes**: Existing functionality remains unchanged; this only adds a fallback mechanism

## Testing Instructions

1. **Setup**:
   - Ensure WooCommerce is active
   - Configure a connector (e.g., Clientify) with custom field mappings in `prod_mergevars`
   - Map a custom field where the API response uses the source key name instead of the mapped field name

2. **Test custom field import**:
   - Navigate to: **WooCommerce > Settings > Connect Ecommerce > [Your Connector]**
   - Configure product mergevars to map a custom field (e.g., `source_field_name` → `cf|_custom_meta_key`)
   - Ensure the API response contains `source_field_name` but not the mapped field name
   - Run a product import via: **WooCommerce > Connect Ecommerce > Import Products** or WP-CLI: `wp conecom import products`

3. **Verify results**:
   - Check that products are imported successfully
   - Navigate to a product edit page: **Products > All Products > [Imported Product]**
   - Verify that the custom field value is correctly imported and visible in the product meta data
   - Check product meta using: `get_post_meta( $product_id, '_custom_meta_key', true )`

4. **Expected behavior**:
   - Custom fields should be imported using the source key when the mapped field name is not available
   - No errors should occur during import
   - Custom field values should match the API response values

## Checklist

- [x] Code follows WordPress Coding Standards
- [x] Self-reviewed the code
- [x] Added necessary comments
- [x] No new linter errors
- [x] Changelog updated
- [x] Tested with actual API import
