### PR TITLE
Update Reduced date for RO

### DIFF
--- a/includes/Helpers/TAXES.php
+++ b/includes/Helpers/TAXES.php
@@ -318,14 +318,14 @@ class TAXES {
 				'super_reduced_rate' => false,
 				'parking_rate'       => 13.00,
 			),
-			'RO' => array(
-				'country'            => __( 'Romania', 'woocommerce-es' ),
-				'standard_rate'      => 19.00,
-				'reduced_rate'       => 9.00,
-				'reduced_rate_alt'   => 5.00,
-				'super_reduced_rate' => false,
-				'parking_rate'       => false,
-			),
+		'RO' => array(
+			'country'            => __( 'Romania', 'woocommerce-es' ),
+			'standard_rate'      => 19.00,
+			'reduced_rate'       => 11.00,
+			'reduced_rate_alt'   => 5.00,
+			'super_reduced_rate' => false,
+			'parking_rate'       => false,
+		),
 			'SI' => array(
 				'country'            => __( 'Slovenia', 'woocommerce-es' ),
 				'standard_rate'      => 22.00,


### PR DESCRIPTION
Update Romania's reduced VAT rate from 9% to 11% to resolve issue #140.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-cf5d2e6c-17d8-4961-b4bf-22c6e976b57b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf5d2e6c-17d8-4961-b4bf-22c6e976b57b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

