### PR TITLE
Refactor sync settings: remove Automate tab, move frequency to Products, add sync stats and AS logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This agent has access to the **agent-browser** CLI tool. Use it to test and debug web applications and websites end-to-end (e.g. opening URLs, interacting with the WordPress admin or storefront, checking sync or checkout flows).
+
+You can also use **WordPress Playground** (e.g. via `npx @wp-playground/cli`) to spin up a disposable WordPress instance and test the plugin, sync, or checkout flows without a full local stack.

--- a/includes/Admin/Import_Products.php
+++ b/includes/Admin/Import_Products.php
@@ -88,6 +88,7 @@ class Import_Products {
 		// Admin Styles.
 		add_action( 'wp_ajax_connect_ecommerce_sync_products', array( $this, 'sync_products' ) );
 		add_action( 'wp_ajax_connect_ecommerce_get_import_stats', array( $this, 'get_import_stats' ) );
+		add_action( 'wp_ajax_connect_ecommerce_get_as_logs', array( $this, 'get_as_logs' ) );
 
 		// Schedule.
 		if ( $this->sync_period && 'no' !== $this->sync_period ) {
@@ -189,6 +190,7 @@ class Import_Products {
 				'nonce'                    => wp_create_nonce( 'conecom_manual_import_nonce' ),
 				'has_get_all_product_skus' => $has_get_all_product_skus,
 				'stats_nonce'              => wp_create_nonce( 'conecom_import_stats_nonce' ),
+				'as_logs_nonce'            => wp_create_nonce( 'conecom_as_logs_nonce' ),
 			)
 		);
 
@@ -348,7 +350,7 @@ class Import_Products {
 			return;
 		}
 
-		$result = PROD::get_import_stats( $this->connapi_erp, $this->options );
+		$result = PROD::get_import_stats( $this->connapi_erp, $this->options, $this->settings );
 
 		if ( isset( $result['status'] ) && 'error' === $result['status'] ) {
 			wp_send_json_error( array( 'message' => $result['message'] ) );
@@ -358,7 +360,9 @@ class Import_Products {
 		wp_send_json_success(
 			array(
 				'api_count'       => $result['api_count'],
+				'api_total_count' => $result['api_total_count'],
 				'available_count' => $result['available_count'],
+				'filter_tag'      => $result['filter_tag'],
 				'wp_count'        => $result['wp_count'],
 				'import_count'    => $result['import_count'],
 				'new_count'       => $result['new_count'],
@@ -366,6 +370,32 @@ class Import_Products {
 				'delete_count'    => $result['delete_count'],
 			)
 		);
+	}
+
+	/**
+	 * AJAX handler: returns recent Action Scheduler runs for conecom_sync_* hooks.
+	 *
+	 * @return void
+	 */
+	public function get_as_logs() {
+		if ( ! check_ajax_referer( 'conecom_as_logs_nonce', 'security', false ) ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid nonce', 'woocommerce-es' ) ) );
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Unauthorized', 'woocommerce-es' ) ) );
+			return;
+		}
+
+		$result = CRON::get_sync_logs();
+
+		if ( 'error' === $result['status'] ) {
+			wp_send_json_error( array( 'message' => $result['message'] ) );
+			return;
+		}
+
+		wp_send_json_success( $result['actions'] );
 	}
 
 	/**

--- a/includes/Admin/Import_Products.php
+++ b/includes/Admin/Import_Products.php
@@ -236,7 +236,7 @@ class Import_Products {
 		// Mode (updated|all) can be used in future to filter products to sync when get_all_product_skus exists.
 		$mode = in_array( $mode, array( 'updated', 'all' ), true ) ? $mode : 'all';
 		$generate_ai    = 'true' === $generate_ai ? 'all' : $generate_ai;
-		$api_pagination = ! empty( $this->options['api_pagination'] ) ? $this->options['api_pagination'] : false;
+		$api_pagination = defined( 'CONECOM_SYNC_PRODUCTS_PER_BATCH' ) ? CONECOM_SYNC_PRODUCTS_PER_BATCH : 50;
 
 		// Action for one product.
 		if ( ! empty( $product_erp_id ) ) {

--- a/includes/Admin/Import_Products.php
+++ b/includes/Admin/Import_Products.php
@@ -321,7 +321,7 @@ class Import_Products {
 		$res_message .= '[' . date_i18n( 'H:i:s' ) . ']';
 		if ( 0 <= $sync_loop ) {
 			$res_message .= '[' . $products_synced;
-			$res_message .= empty( $api_pagination ) ? '/' . $products_count : '';
+			$res_message .= ! $api_pagination ? '/' . $products_count : '';
 			$res_message .= '] ';
 		}
 		$res_message .= $message;

--- a/includes/Admin/Import_Products.php
+++ b/includes/Admin/Import_Products.php
@@ -221,10 +221,12 @@ class Import_Products {
 	 * @return void
 	 */
 	public function sync_products() {
+
 		if ( ! check_ajax_referer( 'conecom_manual_import_nonce', 'nonce', false ) ) {
 			wp_send_json_error( array( 'error' => 'Invalid nonce' ) );
 			return;
 		}
+
 		$sync_loop      = isset( $_POST['loop'] ) ? (int) $_POST['loop'] : 0;
 		$product_erp_id = isset( $_POST['product_erp_id'] ) ? sanitize_text_field( wp_unslash( $_POST['product_erp_id'] ) ) : '';
 		$product_sku    = isset( $_POST['product_sku'] ) ? sanitize_text_field( wp_unslash( $_POST['product_sku'] ) ) : '';
@@ -270,6 +272,16 @@ class Import_Products {
 			$api_products                     = $this->connapi_erp->get_products( null, $sync_loop );
 			$_SESSION['conecom_api_products'] = HELPER::sanitize_array_recursive( $api_products );
 			$res_message             .= __( 'Connecting with API...', 'woocommerce-es' ) . '<br/>';
+
+			if ( $sync_loop > 0 && empty( $api_products ) ) {
+				wp_send_json_success( array(
+					'loop'          => $sync_loop,
+					'message'       => '<p class="finish">' . __( 'All caught up!', 'woocommerce-es' ) . '</p>',
+					'finish'        => true,
+					'product_count' => 0,
+				) );
+				return;
+			}
 		} elseif ( 0 < $sync_loop ) {
 			$api_products = isset( $_SESSION['conecom_api_products'] ) ? HELPER::sanitize_array_recursive( $_SESSION['conecom_api_products'] ) : array();
 		}

--- a/includes/Admin/Import_Products.php
+++ b/includes/Admin/Import_Products.php
@@ -87,6 +87,7 @@ class Import_Products {
 
 		// Admin Styles.
 		add_action( 'wp_ajax_connect_ecommerce_sync_products', array( $this, 'sync_products' ) );
+		add_action( 'wp_ajax_connect_ecommerce_get_import_stats', array( $this, 'get_import_stats' ) );
 
 		// Schedule.
 		if ( $this->sync_period && 'no' !== $this->sync_period ) {
@@ -111,7 +112,7 @@ class Import_Products {
 
 		$products_synced = $sync_loop + 1;
 
-		if ( $api_pagination ) {
+		if ( $api_pagination && $api_pagination > 0 ) {
 			// Calculate position within current page (0-indexed).
 			$loop_page = $sync_loop % $api_pagination;
 
@@ -133,12 +134,31 @@ class Import_Products {
 	 * @return void
 	 */
 	public function admin_enqueues() {
+		// Check if we're on connect_ecommerce page.
+		$is_connect_ecommerce_page = isset( $_GET['page'] ) && 'connect_ecommerce' === $_GET['page'];
+		$current_tab               = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : 'synchronization';
+		$current_subtab            = isset( $_GET['subtab'] ) ? sanitize_text_field( wp_unslash( $_GET['subtab'] ) ) : 'sync_products';
+
+		$is_sync_products_page = $is_connect_ecommerce_page
+			&& 'synchronization' === $current_tab
+			&& 'sync_products' === $current_subtab;
+
 		wp_enqueue_style(
 			'woocommerce-es',
 			CONECOM_PLUGIN_URL . 'includes/assets/admin.css',
 			array(),
 			CONECOM_VERSION
 		);
+
+		// Import page layout (tabs, two columns) is always used on sync products; stats are optional.
+		if ( $is_sync_products_page ) {
+			wp_enqueue_style(
+				'conecom-admin-import',
+				CONECOM_PLUGIN_URL . 'includes/assets/admin-import.css',
+				array(),
+				CONECOM_VERSION
+			);
+		}
 
 		wp_enqueue_script(
 			'connect-ecommerce-repeat',
@@ -156,15 +176,19 @@ class Import_Products {
 			true
 		);
 
+		$has_get_all_product_skus = ! empty( $this->connapi_erp ) && method_exists( $this->connapi_erp, 'get_all_product_skus' );
+
 		wp_localize_script(
 			'connect-ecommerce-import',
 			'ConEcom_ajaxAction',
 			array(
-				'url'                 => admin_url( 'admin-ajax.php' ),
-				'label_sync'          => __( 'Sync', 'woocommerce-es' ),
-				'label_syncing'       => __( 'Syncing', 'woocommerce-es' ),
-				'label_sync_complete' => __( 'Finished', 'woocommerce-es' ),
-				'nonce'               => wp_create_nonce( 'conecom_manual_import_nonce' ),
+				'url'                      => admin_url( 'admin-ajax.php' ),
+				'label_sync'               => __( 'Sync', 'woocommerce-es' ),
+				'label_syncing'            => __( 'Syncing', 'woocommerce-es' ),
+				'label_sync_complete'      => __( 'Finished', 'woocommerce-es' ),
+				'nonce'                    => wp_create_nonce( 'conecom_manual_import_nonce' ),
+				'has_get_all_product_skus' => $has_get_all_product_skus,
+				'stats_nonce'              => wp_create_nonce( 'conecom_import_stats_nonce' ),
 			)
 		);
 
@@ -206,6 +230,9 @@ class Import_Products {
 		$message        = '';
 		$res_message    = '';
 		$generate_ai    = ! empty( $_POST['product_ai'] ) ? sanitize_key( $_POST['product_ai'] ) : 'none';
+		$mode           = isset( $_POST['mode'] ) ? sanitize_text_field( wp_unslash( $_POST['mode'] ) ) : 'all';
+		// Mode (updated|all) can be used in future to filter products to sync when get_all_product_skus exists.
+		$mode = in_array( $mode, array( 'updated', 'all' ), true ) ? $mode : 'all';
 		$generate_ai    = 'true' === $generate_ai ? 'all' : $generate_ai;
 		$api_pagination = ! empty( $this->options['api_pagination'] ) ? $this->options['api_pagination'] : false;
 
@@ -232,12 +259,12 @@ class Import_Products {
 			session_start();
 		}
 		$page = 1;
-		if ( $api_pagination ) {
+		if ( $api_pagination && $api_pagination > 0 ) {
 			$loop_page = $sync_loop % $api_pagination;
 			$page      = intval( $sync_loop / $api_pagination, 0 );
 		}
 
-		if ( 0 === $sync_loop || ( $api_pagination && 0 === $loop_page ) ) {
+		if ( 0 === $sync_loop || ( $api_pagination && $api_pagination > 0 && 0 === $loop_page ) ) {
 			$api_products                     = $this->connapi_erp->get_products( null, $sync_loop );
 			$_SESSION['conecom_api_products'] = HELPER::sanitize_array_recursive( $api_products );
 			$res_message             .= __( 'Connecting with API...', 'woocommerce-es' ) . '<br/>';
@@ -308,6 +335,37 @@ class Import_Products {
 			HELPER::send_product_errors( $this->error_product_import, $this->options['slug'] );
 		}
 		wp_send_json_success( $args );
+	}
+
+	/**
+	 * Get import statistics (only when connector has get_all_product_skus).
+	 *
+	 * @return void
+	 */
+	public function get_import_stats() {
+		if ( ! check_ajax_referer( 'conecom_import_stats_nonce', 'security', false ) ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid nonce', 'woocommerce-es' ) ) );
+			return;
+		}
+
+		$result = PROD::get_import_stats( $this->connapi_erp, $this->options );
+
+		if ( isset( $result['status'] ) && 'error' === $result['status'] ) {
+			wp_send_json_error( array( 'message' => $result['message'] ) );
+			return;
+		}
+
+		wp_send_json_success(
+			array(
+				'api_count'       => $result['api_count'],
+				'available_count' => $result['available_count'],
+				'wp_count'        => $result['wp_count'],
+				'import_count'    => $result['import_count'],
+				'new_count'       => $result['new_count'],
+				'outdated_count'  => $result['outdated_count'],
+				'delete_count'    => $result['delete_count'],
+			)
+		);
 	}
 
 	/**

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1110,12 +1110,15 @@ class Settings {
 			$can_sync = 'ok' === $login_api['status'] ? true : false;
 		} else {
 			$can_sync = $login_api;
-			$message = $login_api ? '' : __( 'We couln\'t connect to the API', 'woocommerce-es' );
+			$message  = $login_api ? '' : __( 'We couln\'t connect to the API', 'woocommerce-es' );
 		}
+
+		$has_get_all_product_skus = ! empty( $this->connapi_erp ) && method_exists( $this->connapi_erp, 'get_all_product_skus' );
+		$api_pagination           = ! empty( $this->options['api_pagination'] ) ? (int) $this->options['api_pagination'] : 100;
 		?>
-		<div class="connwoo-sync-engine">
+		<div class="connwoo-sync-engine connwoo-sync-with-stats">
 			<div class="sync-wrapper">
-				<?php 
+				<?php
 				if ( empty( $can_sync ) ) {
 					?>
 					<div class="error notice">
@@ -1127,38 +1130,228 @@ class Settings {
 					</div>
 					<?php
 				} else {
+					$this->render_import_with_stats( $ajax_action, $api_pagination, $has_get_all_product_skus );
+				}
 				?>
-					<h2>
-						<?php
-						echo sprintf(
-							esc_html__( 'Import Products from %s', 'woocommerce-es' ),
-							esc_html( $this->options['name'] )
-						);
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Renders import UI with tabs, sync type selection and optional stats (stats only when get_all_product_skus exists).
+	 *
+	 * @param string $ajax_action AJAX action name.
+	 * @param int    $api_pagination Products per page for sync.
+	 * @param bool   $has_get_all_product_skus Whether connector has get_all_product_skus (shows indicators).
+	 * @return void
+	 */
+	private function render_import_with_stats( $ajax_action, $api_pagination, $has_get_all_product_skus = false ) {
+		$cron_enabled = ! empty( $this->settings['sync'] ) && 'no' !== $this->settings['sync'];
+		?>
+		<h2>
+			<?php
+			printf(
+				/* translators: %s: Name of the connector */
+				esc_html__( 'Import Products from %s', 'woocommerce-es' ),
+				esc_html( $this->options['name'] )
+			);
+			?>
+		</h2>
+
+		<?php
+		if ( $has_get_all_product_skus ) {
+			?>
+		<!-- Import Statistics (only when get_all_product_skus exists) -->
+		<div class="conecom-import-stats">
+			<div class="conecom-stat-card">
+				<div class="conecom-stat-icon conecom-icon-api">
+					<span class="dashicons dashicons-cloud"></span>
+				</div>
+				<div class="conecom-stat-content">
+					<div class="conecom-stat-value" id="stat-available-count">--</div>
+					<div class="conecom-stat-label"><?php esc_html_e( 'Available in API', 'woocommerce-es' ); ?></div>
+				</div>
+			</div>
+
+			<div class="conecom-stat-card">
+				<div class="conecom-stat-icon conecom-icon-wp">
+					<span class="dashicons dashicons-cart"></span>
+				</div>
+				<div class="conecom-stat-content">
+					<div class="conecom-stat-value" id="stat-wp-count">--</div>
+					<div class="conecom-stat-label"><?php esc_html_e( 'Products in WooCommerce', 'woocommerce-es' ); ?></div>
+					<div class="conecom-stat-sublabel"><?php esc_html_e( 'Synced products', 'woocommerce-es' ); ?></div>
+				</div>
+			</div>
+
+			<div class="conecom-stat-card conecom-stat-import">
+				<div class="conecom-stat-icon conecom-icon-import">
+					<span class="dashicons dashicons-download"></span>
+				</div>
+				<div class="conecom-stat-content">
+					<div class="conecom-stat-value" id="stat-import-count">--</div>
+					<div class="conecom-stat-label"><?php esc_html_e( 'To Import/Update', 'woocommerce-es' ); ?></div>
+					<div class="conecom-stat-sublabel">
+						<span id="stat-new-count">--</span> <?php esc_html_e( 'new', 'woocommerce-es' ); ?> +
+						<span id="stat-outdated-count">--</span> <?php esc_html_e( 'outdated', 'woocommerce-es' ); ?>
+					</div>
+				</div>
+			</div>
+
+			<div class="conecom-stat-card conecom-stat-delete">
+				<div class="conecom-stat-icon conecom-icon-delete">
+					<span class="dashicons dashicons-trash"></span>
+				</div>
+				<div class="conecom-stat-content">
+					<div class="conecom-stat-value" id="stat-delete-count">--</div>
+					<div class="conecom-stat-label"><?php esc_html_e( 'To Remove', 'woocommerce-es' ); ?></div>
+					<div class="conecom-stat-sublabel"><?php esc_html_e( 'Not in API', 'woocommerce-es' ); ?></div>
+				</div>
+			</div>
+		</div>
+			<?php
+		}
+		?>
+
+		<!-- Two columns: Automatic Sync + Manual Import -->
+		<div class="conecom-two-columns">
+			<div class="conecom-cron-logs">
+				<h3>
+					<span class="dashicons dashicons-clock" style="vertical-align: middle;"></span>
+					<?php esc_html_e( 'Automatic Sync (Cron)', 'woocommerce-es' ); ?>
+					<?php if ( $cron_enabled ) : ?>
+						<span style="color: green; font-size: 0.8em; font-weight: normal;">● <?php esc_html_e( 'Enabled', 'woocommerce-es' ); ?></span>
+					<?php else : ?>
+						<span style="color: #999; font-size: 0.8em; font-weight: normal;">○ <?php esc_html_e( 'Disabled', 'woocommerce-es' ); ?></span>
+					<?php endif; ?>
+				</h3>
+				<p style="color: #646970; font-size: 14px; margin-top: 10px;">
+					<?php esc_html_e( 'Configure sync frequency in the Automate tab.', 'woocommerce-es' ); ?>
+				</p>
+			</div>
+
+			<div class="conecom-manual-import">
+				<h3>
+					<span class="dashicons dashicons-upload" style="vertical-align: middle;"></span>
+					<?php esc_html_e( 'Manual Import', 'woocommerce-es' ); ?>
+				</h3>
+
+				<div class="import-button-wrapper">
+					<select id="import-mode" class="import-mode-select">
+						<option value="updated"><?php esc_html_e( 'Products to update', 'woocommerce-es' ); ?></option>
+						<option value="all"><?php esc_html_e( 'All products', 'woocommerce-es' ); ?></option>
+					</select>
+					<button type="button" id="sync-products" name="sync-products" class="button button-large button-primary" onclick="syncManualItemsWithMode(this, '<?php echo esc_attr( $ajax_action ); ?>', 0, <?php echo (int) $api_pagination; ?>);"><?php esc_html_e( 'Start Import', 'woocommerce-es' ); ?></button>
+					<?php
+					if ( $has_get_all_product_skus ) {
 						?>
-					</h2>
-					<p><?php esc_html_e( 'After you fillup the API settings, use the button below to import the products. The importing process may take a while and you need to keep this page open to complete it.', 'woocommerce-es' ); ?>
-					</p>
-					<br/>
-					<div id="sync-products" name="sync-products" class="button button-large button-primary" onclick="syncManualItems(this, '<?php echo esc_attr( $ajax_action ); ?>', 0);" ><?php esc_html_e( 'Start Import', 'woocommerce-es' ); ?></div>
-					<?php if ( ! $this->is_disabled_ai ) { ?>
-						<p>
-						<label for="<?php echo esc_attr( 'connect_ecommerce_ai' ); ?>"><?php esc_html_e( 'AI generation SEO options for products:', 'woocommerce-es' ); ?></label>
-						<select name="connwoo-sync-product-ai" id="<?php echo esc_attr( 'connect_ecommerce_ai' ); ?>">
+					<button type="button" id="refresh_stats" name="refresh_stats" class="button button-large" onclick="loadImportStats();">
+						<span class="dashicons dashicons-update"></span>
+						<?php esc_html_e( 'Refresh Statistics', 'woocommerce-es' ); ?>
+					</button>
+						<?php
+					}
+					?>
+					<span class="spinner"></span>
+				</div>
+				<?php
+				if ( ! $this->is_disabled_ai ) {
+					?>
+					<p style="margin-top: 10px;">
+						<label for="connect_ecommerce_ai_stats"><?php esc_html_e( 'AI generation SEO options for products:', 'woocommerce-es' ); ?></label>
+						<select name="connwoo-sync-product-ai" id="connect_ecommerce_ai_stats">
 							<option value="none"><?php esc_html_e( 'None', 'woocommerce-es' ); ?></option>
 							<option value="new"><?php esc_html_e( 'NEW Products', 'woocommerce-es' ); ?></option>
 							<option value="all"><?php esc_html_e( 'ALL Products', 'woocommerce-es' ); ?></option>
 						</select>
-						</p>
-					<?php } ?>
-				</div>
-				<fieldset id="logwrapper">
-					<legend><?php esc_html_e( 'Log', 'woocommerce-es' ); ?></legend>
-					<div id="loglist"></div>
-				</fieldset>
-				<?php
+					</p>
+					<?php
 				}
 				?>
+			</div>
 		</div>
+
+		<!-- Log container with tabs -->
+		<div class="conecom-log-container">
+			<div class="conecom-log-tabs">
+				<button class="conecom-tab-button active" data-tab="automatic">
+					<span class="dashicons dashicons-clock"></span>
+					<?php esc_html_e( 'Automatic Sync', 'woocommerce-es' ); ?>
+				</button>
+				<button class="conecom-tab-button" data-tab="manual">
+					<span class="dashicons dashicons-upload"></span>
+					<?php esc_html_e( 'Manual Import', 'woocommerce-es' ); ?>
+				</button>
+			</div>
+
+			<div class="conecom-tab-content">
+				<div class="conecom-tab-pane active" id="tab-automatic">
+					<p style="color: #666; font-style: italic; padding: 20px; text-align: center;">
+						<?php esc_html_e( 'Automatic sync runs in the background. Check WooCommerce logs for details.', 'woocommerce-es' ); ?>
+					</p>
+				</div>
+				<div class="conecom-tab-pane" id="tab-manual">
+					<fieldset id="logwrapper" style="border: none; padding: 0; margin: 0;">
+						<div id="loglist"></div>
+					</fieldset>
+				</div>
+			</div>
+		</div>
+
+		<script type="text/javascript">
+		function loadImportStats() {
+			if ( typeof ConEcom_ajaxAction === 'undefined' || ! ConEcom_ajaxAction.has_get_all_product_skus ) {
+				return;
+			}
+			var btn = document.getElementById('refresh_stats');
+			var cards = document.querySelectorAll('.conecom-stat-card');
+			if ( btn ) { btn.disabled = true; }
+			if ( cards.length ) { cards.forEach(function(c){ c.classList.add('loading'); }); }
+
+			fetch(ConEcom_ajaxAction.url, {
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+				body: 'action=connect_ecommerce_get_import_stats&security=' + encodeURIComponent(ConEcom_ajaxAction.stats_nonce)
+			})
+			.then(function(r){ return r.json(); })
+			.then(function(response) {
+				if ( response.success && response.data ) {
+					var d = response.data;
+					var set = function(id, val) { var el = document.getElementById(id); if (el) el.textContent = (typeof val === 'number') ? val.toLocaleString() : val; };
+					set('stat-available-count', d.available_count);
+					set('stat-wp-count', d.wp_count);
+					set('stat-import-count', d.import_count);
+					set('stat-new-count', d.new_count);
+					set('stat-outdated-count', d.outdated_count);
+					set('stat-delete-count', d.delete_count);
+				}
+			})
+			.catch(function() {})
+			.finally(function() {
+				if ( btn ) { btn.disabled = false; }
+				if ( cards.length ) { cards.forEach(function(c){ c.classList.remove('loading'); }); }
+			});
+		}
+		document.addEventListener('DOMContentLoaded', function() {
+			var tabButtons = document.querySelectorAll('.conecom-tab-button');
+			var tabPanes = document.querySelectorAll('.conecom-tab-pane');
+			tabButtons.forEach(function(btn) {
+				btn.addEventListener('click', function() {
+					var targetTab = this.getAttribute('data-tab');
+					tabButtons.forEach(function(b){ b.classList.remove('active'); });
+					tabPanes.forEach(function(p){ p.classList.remove('active'); });
+					this.classList.add('active');
+					var pane = document.getElementById('tab-' + targetTab);
+					if ( pane ) pane.classList.add('active');
+				});
+			});
+			if ( typeof ConEcom_ajaxAction !== 'undefined' && ConEcom_ajaxAction.has_get_all_product_skus ) {
+				loadImportStats();
+			}
+		});
+		</script>
 		<?php
 	}
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1243,14 +1243,6 @@ class Settings {
 						</select>
 						</p>
 					<?php } ?>
-					</div>
-					<fieldset id="logwrapper">
-						<legend><?php esc_html_e( 'Log', 'woocommerce-es' ); ?></legend>
-						<div id="loglist"></div>
-					</fieldset>
-					<?php
-				}
-				?>
 			</div>
 		</div>
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1170,7 +1170,16 @@ class Settings {
 				</div>
 				<div class="conecom-stat-content">
 					<div class="conecom-stat-value" id="stat-available-count">--</div>
-					<div class="conecom-stat-label"><?php esc_html_e( 'Available in API', 'woocommerce-es' ); ?></div>
+					<div class="conecom-stat-label">
+						<?php
+						printf(
+							/* translators: %s: Name of the ERP connector */
+							esc_html__( 'Available in %s', 'woocommerce-es' ),
+							esc_html( $this->options['name'] )
+						);
+						?>
+					</div>
+					<div class="conecom-stat-sublabel" id="stat-available-sublabel" style="display:none;"></div>
 				</div>
 			</div>
 
@@ -1285,11 +1294,13 @@ class Settings {
 			</div>
 
 			<div class="conecom-tab-content">
-				<div class="conecom-tab-pane active" id="tab-automatic">
+			<div class="conecom-tab-pane active" id="tab-automatic">
+				<div id="conecom-as-logs-container">
 					<p style="color: #666; font-style: italic; padding: 20px; text-align: center;">
-						<?php esc_html_e( 'Automatic sync runs in the background. Check WooCommerce logs for details.', 'woocommerce-es' ); ?>
+						<?php esc_html_e( 'Loading...', 'woocommerce-es' ); ?>
 					</p>
 				</div>
+			</div>
 				<div class="conecom-tab-pane" id="tab-manual">
 					<fieldset id="logwrapper" style="border: none; padding: 0; margin: 0;">
 						<div id="loglist"></div>
@@ -1315,42 +1326,140 @@ class Settings {
 				body: 'action=connect_ecommerce_get_import_stats&security=' + encodeURIComponent(ConEcom_ajaxAction.stats_nonce)
 			})
 			.then(function(r){ return r.json(); })
-			.then(function(response) {
-				if ( response.success && response.data ) {
-					var d = response.data;
-					var set = function(id, val) { var el = document.getElementById(id); if (el) el.textContent = (typeof val === 'number') ? val.toLocaleString() : val; };
-					set('stat-available-count', d.available_count);
-					set('stat-wp-count', d.wp_count);
-					set('stat-import-count', d.import_count);
-					set('stat-new-count', d.new_count);
-					set('stat-outdated-count', d.outdated_count);
-					set('stat-delete-count', d.delete_count);
+		.then(function(response) {
+			if ( response.success && response.data ) {
+				var d = response.data;
+				var set = function(id, val) { var el = document.getElementById(id); if (el) el.textContent = (typeof val === 'number') ? val.toLocaleString() : val; };
+				set('stat-available-count', d.available_count);
+				set('stat-wp-count', d.wp_count);
+				set('stat-import-count', d.import_count);
+				set('stat-new-count', d.new_count);
+				set('stat-outdated-count', d.outdated_count);
+				set('stat-delete-count', d.delete_count);
+
+				var sublabel = document.getElementById('stat-available-sublabel');
+				if ( sublabel ) {
+					if ( d.filter_tag && d.api_total_count !== undefined && d.api_total_count !== d.available_count ) {
+						sublabel.style.display = '';
+						sublabel.innerHTML = '<?php esc_html_e( 'Tag:', 'woocommerce-es' ); ?> <strong>' + d.filter_tag + '</strong>'
+							+ '<br><small><?php esc_html_e( 'Total:', 'woocommerce-es' ); ?> ' + Number(d.api_total_count).toLocaleString() + '</small>';
+					} else {
+						sublabel.style.display = 'none';
+						sublabel.innerHTML = '';
+					}
 				}
-			})
+			}
+		})
 			.catch(function() {})
 			.finally(function() {
 				if ( btn ) { btn.disabled = false; }
 				if ( cards.length ) { cards.forEach(function(c){ c.classList.remove('loading'); }); }
 			});
 		}
-		document.addEventListener('DOMContentLoaded', function() {
-			var tabButtons = document.querySelectorAll('.conecom-tab-button');
-			var tabPanes = document.querySelectorAll('.conecom-tab-pane');
-			tabButtons.forEach(function(btn) {
-				btn.addEventListener('click', function() {
-					var targetTab = this.getAttribute('data-tab');
-					tabButtons.forEach(function(b){ b.classList.remove('active'); });
-					tabPanes.forEach(function(p){ p.classList.remove('active'); });
-					this.classList.add('active');
-					var pane = document.getElementById('tab-' + targetTab);
-					if ( pane ) pane.classList.add('active');
-				});
-			});
-			if ( typeof ConEcom_ajaxAction !== 'undefined' && ConEcom_ajaxAction.has_get_all_product_skus ) {
-				loadImportStats();
+	function loadAsLogs() {
+		if ( typeof ConEcom_ajaxAction === 'undefined' ) { return; }
+		var container = document.getElementById('conecom-as-logs-container');
+		if ( ! container ) { return; }
+		container.innerHTML = '<p style="color:#666;font-style:italic;padding:20px;text-align:center;"><?php esc_html_e( 'Loading…', 'woocommerce-es' ); ?></p>';
+
+		fetch(ConEcom_ajaxAction.url, {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: 'action=connect_ecommerce_get_as_logs&security=' + encodeURIComponent(ConEcom_ajaxAction.as_logs_nonce)
+		})
+		.then(function(r){ return r.json(); })
+		.then(function(response) {
+			if ( ! response.success ) {
+				container.innerHTML = '<p style="color:#d63638;padding:20px;">' + ( response.data && response.data.message ? response.data.message : '<?php esc_html_e( 'Error loading logs.', 'woocommerce-es' ); ?>' ) + '</p>';
+				return;
 			}
+			var actions = response.data;
+			if ( ! actions || actions.length === 0 ) {
+				container.innerHTML = '<p style="color:#666;font-style:italic;padding:20px;text-align:center;"><?php esc_html_e( 'No sync runs recorded yet.', 'woocommerce-es' ); ?></p>';
+				return;
+			}
+
+			var statusLabels = {
+				'complete':    '<?php esc_html_e( 'Complete', 'woocommerce-es' ); ?>',
+				'failed':      '<?php esc_html_e( 'Failed', 'woocommerce-es' ); ?>',
+				'pending':     '<?php esc_html_e( 'Pending', 'woocommerce-es' ); ?>',
+				'in-progress': '<?php esc_html_e( 'Running', 'woocommerce-es' ); ?>',
+				'canceled':    '<?php esc_html_e( 'Canceled', 'woocommerce-es' ); ?>'
+			};
+			var statusColors = {
+				'complete':    '#00a32a',
+				'failed':      '#d63638',
+				'pending':     '#dba617',
+				'in-progress': '#2271b1',
+				'canceled':    '#787c82'
+			};
+
+			var html = '<table class="widefat striped" style="margin:0;">'
+				+ '<thead><tr>'
+				+ '<th style="width:160px;"><?php esc_html_e( 'Date', 'woocommerce-es' ); ?></th>'
+				+ '<th style="width:100px;"><?php esc_html_e( 'Status', 'woocommerce-es' ); ?></th>'
+				+ '<th style="width:130px;"><?php esc_html_e( 'Frequency', 'woocommerce-es' ); ?></th>'
+				+ '<th><?php esc_html_e( 'Last log', 'woocommerce-es' ); ?></th>'
+				+ '</tr></thead><tbody>';
+
+			actions.forEach(function(action) {
+				var status      = action.status || 'pending';
+				var color       = statusColors[status] || '#787c82';
+				var statusLabel = statusLabels[status] || status;
+				var lastLog     = action.logs && action.logs.length ? action.logs[action.logs.length - 1].message : '—';
+				var rowId       = 'as-log-row-' + action.id;
+				var detailId    = 'as-log-detail-' + action.id;
+				var hasLogs     = action.logs && action.logs.length > 1;
+
+				html += '<tr id="' + rowId + '" style="cursor:' + ( hasLogs ? 'pointer' : 'default' ) + ';" '
+					+ ( hasLogs ? 'onclick="document.getElementById(\'' + detailId + '\').style.display = document.getElementById(\'' + detailId + '\').style.display === \'none\' ? \'\' : \'none\';"' : '' )
+					+ '>'
+					+ '<td style="white-space:nowrap;font-size:12px;">' + action.scheduled_date + '</td>'
+					+ '<td><span style="color:' + color + ';font-weight:600;">' + statusLabel + '</span></td>'
+					+ '<td style="font-size:12px;">' + action.hook_label + '</td>'
+					+ '<td style="font-size:12px;color:#50575e;">' + lastLog + '</td>'
+					+ '</tr>';
+
+				if ( hasLogs ) {
+					html += '<tr id="' + detailId + '" style="display:none;background:#f6f7f7;">'
+						+ '<td colspan="4" style="padding:8px 16px;">'
+						+ '<ol style="margin:0;padding-left:20px;">';
+					action.logs.forEach(function(log) {
+						html += '<li style="font-size:12px;margin-bottom:2px;"><span style="color:#50575e;">[' + log.date + ']</span> ' + log.message + '</li>';
+					});
+					html += '</ol></td></tr>';
+				}
+			});
+
+			html += '</tbody></table>';
+			container.innerHTML = html;
+		})
+		.catch(function() {
+			container.innerHTML = '<p style="color:#d63638;padding:20px;"><?php esc_html_e( 'Error loading logs.', 'woocommerce-es' ); ?></p>';
 		});
-		</script>
+	}
+
+	document.addEventListener('DOMContentLoaded', function() {
+		var tabButtons = document.querySelectorAll('.conecom-tab-button');
+		var tabPanes = document.querySelectorAll('.conecom-tab-pane');
+		tabButtons.forEach(function(btn) {
+			btn.addEventListener('click', function() {
+				var targetTab = this.getAttribute('data-tab');
+				tabButtons.forEach(function(b){ b.classList.remove('active'); });
+				tabPanes.forEach(function(p){ p.classList.remove('active'); });
+				this.classList.add('active');
+				var pane = document.getElementById('tab-' + targetTab);
+				if ( pane ) pane.classList.add('active');
+				if ( 'automatic' === targetTab ) { loadAsLogs(); }
+			});
+		});
+		if ( typeof ConEcom_ajaxAction !== 'undefined' && ConEcom_ajaxAction.has_get_all_product_skus ) {
+			loadImportStats();
+		}
+		loadAsLogs();
+	});
+	</script>
 		<?php
 	}
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1205,8 +1205,7 @@ class Settings {
 				</div>
 				<div class="conecom-stat-content">
 					<div class="conecom-stat-value" id="stat-delete-count">--</div>
-					<div class="conecom-stat-label"><?php esc_html_e( 'To Remove', 'woocommerce-es' ); ?></div>
-					<div class="conecom-stat-sublabel"><?php esc_html_e( 'Not in API', 'woocommerce-es' ); ?></div>
+					<div class="conecom-stat-label"><?php esc_html_e( 'Not in API', 'woocommerce-es' ); ?></div>
 				</div>
 			</div>
 		</div>

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -287,15 +287,14 @@ class Settings {
 				if ( 'synchronization' === $active_tab && $this->connector ) {
 					?>
 					<ul class="subsubsub">
-						<li><a href="?page=connect_ecommerce&tab=synchronization&subtab=sync_products" class="<?php echo 'sync_products' === $active_subtab ? 'current' : ''; ?>"><?php esc_html_e( 'Products', 'woocommerce-es' ); ?></a> | </li>
+						<li><a href="?page=connect_ecommerce&tab=synchronization&subtab=sync_products" class="<?php echo 'sync_products' === $active_subtab ? 'current' : ''; ?>"><?php esc_html_e( 'Products', 'woocommerce-es' ); ?></a><?php echo ( ! $this->is_disabled_orders ) ? ' | ' : ''; ?></li>
 						<?php
 						if ( ! $this->is_disabled_orders ) {
 							?>
-							<li><a href="?page=connect_ecommerce&tab=synchronization&subtab=sync_orders" class="<?php echo 'sync_orders' === $active_subtab ? 'current' : ''; ?>"><?php esc_html_e( 'Orders', 'woocommerce-es' ); ?></a> | </li>
+							<li><a href="?page=connect_ecommerce&tab=synchronization&subtab=sync_orders" class="<?php echo 'sync_orders' === $active_subtab ? 'current' : ''; ?>"><?php esc_html_e( 'Orders', 'woocommerce-es' ); ?></a></li>
 							<?php
 						}
 						?>
-						<li><a href="?page=connect_ecommerce&tab=synchronization&subtab=automate" class="<?php echo 'automate' === $active_subtab ? 'current' : ''; ?>"><?php esc_html_e( 'Automate', 'woocommerce-es' ); ?></a></li>
 					</ul>
 					<br class="clear">
 					<?php
@@ -339,22 +338,6 @@ class Settings {
 				if ( 'synchronization' === $active_tab ) {
 					if ( 'sync_products' === $active_subtab || 'sync_orders' === $active_subtab ) {
 						$this->page_get_sync( $active_subtab );
-					}
-
-					if ( 'automate' === $active_subtab ) {
-						?>
-						<form method="post" action="options.php">
-							<?php
-							settings_fields( 'connect_ecommerce_settings' );
-							do_settings_sections( 'connect_ecommerce_automate' );
-							submit_button(
-								__( 'Save automate', 'woocommerce-es' ),
-								'primary',
-								'submit_automate'
-							);
-							?>
-						</form>
-						<?php
 					}
 				}
 
@@ -856,42 +839,6 @@ class Settings {
 		}
 
 		/**
-		 * ## Automate
-		 * --------------------------- */
-
-		add_settings_section(
-			'connect_woocommerce_setting_automate',
-			__( 'Automate', 'woocommerce-es' ),
-			array( $this, 'section_automate' ),
-			'connect_ecommerce_automate'
-		);
-
-		add_settings_field(
-			'wcpimh_sync',
-			__( 'When do you want to sync?', 'woocommerce-es' ),
-			array( $this, 'sync_callback' ),
-			'connect_ecommerce_automate',
-			'connect_woocommerce_setting_automate'
-		);
-
-		if ( ! empty( $this->options['table_sync'] ) ) {
-			add_settings_field(
-				'wcpimh_sync_num',
-				__( 'How many products do you want to sync each time?', 'woocommerce-es' ),
-				array( $this, 'sync_num_callback' ),
-				'connect_ecommerce_automate',
-				'connect_woocommerce_setting_automate'
-			);
-			add_settings_field(
-				'wcpimh_sync_email',
-				__( 'Do you want to receive an email when all products are synced?', 'woocommerce-es' ),
-				array( $this, 'sync_email_callback' ),
-				'connect_ecommerce_automate',
-				'connect_woocommerce_setting_automate'
-			);
-		}
-
-		/**
 		 * ## Merge Vars
 		 * --------------------------- */
 
@@ -1071,6 +1018,14 @@ class Settings {
 		);
 
 		add_settings_field(
+			'connect_ecommerce_alert_product_synced',
+			__( 'Enable Alerts Product synced', 'woocommerce-es' ),
+			array( $this, 'alert_product_synced_callback' ),
+			'connect_ecommerce_alerts',
+			'connect_ecommerce_alerts_section'
+		);
+
+		add_settings_field(
 			'connect_ecommerce_alert_method',
 			__( 'Alert Method', 'woocommerce-es' ),
 			array( $this, 'alert_method_callback' ),
@@ -1114,7 +1069,7 @@ class Settings {
 		}
 
 		$has_get_all_product_skus = ! empty( $this->connapi_erp ) && method_exists( $this->connapi_erp, 'get_all_product_skus' );
-		$api_pagination           = ! empty( $this->options['api_pagination'] ) ? (int) $this->options['api_pagination'] : 100;
+		$api_pagination           = defined( 'CONECOM_SYNC_PRODUCTS_PER_BATCH' ) ? CONECOM_SYNC_PRODUCTS_PER_BATCH : 50;
 		?>
 		<div class="connwoo-sync-engine connwoo-sync-with-stats">
 			<div class="sync-wrapper">
@@ -1235,8 +1190,17 @@ class Settings {
 					<?php endif; ?>
 				</h3>
 				<p style="color: #646970; font-size: 14px; margin-top: 10px;">
-					<?php esc_html_e( 'Configure sync frequency in the Automate tab.', 'woocommerce-es' ); ?>
+					<?php esc_html_e( 'Choose when to run automatic sync below.', 'woocommerce-es' ); ?>
 				</p>
+				<form method="post" action="<?php echo esc_url( admin_url( 'options.php' ) ); ?>" style="margin-top: 12px;">
+					<?php settings_fields( 'connect_ecommerce_settings' ); ?>
+					<input type="hidden" name="connect_ecommerce[connector]" value="<?php echo esc_attr( $this->connector ); ?>" />
+					<p style="display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin: 0;">
+						<label for="wcpimh_sync" style="margin: 0;"><?php esc_html_e( 'When do you want to sync?', 'woocommerce-es' ); ?></label>
+						<?php $this->sync_callback(); ?>
+						<?php submit_button( __( 'Save', 'woocommerce-es' ), 'secondary', 'submit_sync_frequency', false ); ?>
+					</p>
+				</form>
 			</div>
 
 			<div class="conecom-manual-import">
@@ -1530,8 +1494,6 @@ class Settings {
 				'order_tags'         => '',
 				'design_id'          => '',
 				'sync'               => 'no',
-				'sync_num'           => 5,
-				'sync_email'         => 'yes',
 				'prod_weight_eq'     => '',
 				'debug_log'          => 'no',
 			],
@@ -1549,45 +1511,6 @@ class Settings {
 		$sanitary_values['connector'] = $connector;
 
 		return $sanitary_values;
-	}
-
-	/**
-	 * Info for holded section.
-	 *
-	 * @return void
-	 */
-	public function section_automate() {
-		?>
-		<input type="hidden" name="connect_ecommerce[connector]" value="<?php echo esc_attr( $this->connector ); ?>" />
-		<?php
-		if ( empty( $this->options['table_sync'] ) ) {
-			return;
-		}
-		global $wpdb;
-		$table_sync = $this->options['table_sync'];
-		HELPER::check_table_sync( $table_sync );
-		$count        = $wpdb->get_var( "SELECT COUNT(*) FROM $table_sync WHERE synced = 1" );
-		$total_count  = $wpdb->get_var( "SELECT COUNT(*) FROM $table_sync" );
-		$count_return = $count . ' / ' . $total_count;
-
-		$total_api_products = (int) get_option( 'connect_ecommerce_total_api_products' );
-		if ( $total_api_products || $total_count !== $total_api_products ) {
-			$count_return .= ' ' . esc_html__( 'filtered', 'woocommerce-es' );
-			$count_return .= ' ( ' . $total_api_products . ' ' . esc_html__( 'total', 'woocommerce-es' ) . ' )';
-		}
-		$percentage = 0 < $total_count ? intval( $count / $total_count * 100 ) : 0;
-		esc_html_e( 'Make your settings to automate the sync.', 'woocommerce-es' );
-		echo '<div class="sync-status" style="text-align:right;">';
-		echo '<strong>';
-		esc_html_e( 'Actual Automate status:', 'woocommerce-es' );
-		echo '</strong> ' . esc_html( $count_return ) . ' ';
-		esc_html_e( 'products synced with ', 'woocommerce-es' );
-		echo esc_html( $this->options['name'] );
-		echo '</div>';
-		echo '<div class="progress-bar blue">
-		<span style="width:' . esc_html( $percentage ) . '%"></span>
-		<div class="progress-text">' . esc_html( $percentage ) . '%</div>
-		</div>';
 	}
 
 	/**
@@ -2184,33 +2107,6 @@ class Settings {
 	}
 
 	/**
-	 * Callback sync field.
-	 *
-	 * @return void
-	 */
-	public function sync_num_callback() {
-		printf(
-			'<input class="regular-text" type="text" name="connect_ecommerce[' . esc_html( $this->connector ) . '][sync_num]" id="wcpimh_sync_num" value="%s">',
-			isset( $this->settings['sync_num'] ) ? esc_attr( $this->settings['sync_num'] ) : 5
-		);
-	}
-
-	/**
-	 * Sync email options
-	 *
-	 * @return void
-	 */
-	public function sync_email_callback() {
-		$sync_email = isset( $this->settings['sync_email'] ) ? $this->settings['sync_email'] : 'no';
-		?>
-		<select name="connect_ecommerce[<?php echo esc_html( $this->connector ); ?>][sync_email]" id="wcpimh_sync_email">
-			<option value="yes" <?php selected( $sync_email, 'yes' ); ?>><?php esc_html_e( 'Yes', 'woocommerce-es' ); ?></option>
-			<option value="no" <?php selected( $sync_email, 'no' ); ?>><?php esc_html_e( 'No', 'woocommerce-es' ); ?></option>
-		</select>
-		<?php
-	}
-
-	/**
 	 * ## Merge vars
 	 * --------------------------- */
 
@@ -2517,6 +2413,23 @@ class Settings {
 	}
 
 	/**
+	 * Alert product synced callback.
+	 *
+	 * @return void
+	 */
+	public function alert_product_synced_callback() {
+		$settings = get_option( 'connect_ecommerce_alerts' );
+		$value    = isset( $settings['alert_product_synced'] ) ? $settings['alert_product_synced'] : 'no';
+		?>
+		<select name="connect_ecommerce_alerts[alert_product_synced]" id="alert_product_synced">
+			<option value="no" <?php selected( $value, 'no' ); ?>><?php esc_html_e( 'No', 'woocommerce-es' ); ?></option>
+			<option value="yes" <?php selected( $value, 'yes' ); ?>><?php esc_html_e( 'Yes', 'woocommerce-es' ); ?></option>
+		</select>
+		<p class="description"><?php esc_html_e( 'Receive an email when all products have been synced.', 'woocommerce-es' ); ?></p>
+		<?php
+	}
+
+	/**
 	 * Alert method callback
 	 *
 	 * @return void
@@ -2582,6 +2495,10 @@ class Settings {
 
 		if ( isset( $input['alert_enabled'] ) ) {
 			$sanitary_values['alert_enabled'] = sanitize_text_field( $input['alert_enabled'] );
+		}
+
+		if ( isset( $input['alert_product_synced'] ) ) {
+			$sanitary_values['alert_product_synced'] = sanitize_text_field( $input['alert_product_synced'] );
 		}
 
 		if ( isset( $input['alert_method'] ) ) {

--- a/includes/CLI/Import_Products_Command.php
+++ b/includes/CLI/Import_Products_Command.php
@@ -60,7 +60,7 @@ class Import_Products_Command {
 
 		$options        = $connector_data['options'];
 		$connapi_erp    = $connector_data['connapi_erp'];
-		$api_pagination = ! empty( $options['api_pagination'] ) ? $options['api_pagination'] : false;
+		$api_pagination  = defined( 'CONECOM_SYNC_PRODUCTS_PER_BATCH' ) ? CONECOM_SYNC_PRODUCTS_PER_BATCH : 50;
 		$generate_ai     = $assoc_args['ai'] ?? 'none';
 
 		// Loop Products.

--- a/includes/Helpers/CRON.php
+++ b/includes/Helpers/CRON.php
@@ -337,4 +337,83 @@ class CRON {
 			),
 		);
 	}
+
+	/**
+	 * Returns recent Action Scheduler runs for conecom_sync_* hooks.
+	 *
+	 * @return array { status: 'success'|'error', actions?: array, message?: string }
+	 */
+	public static function get_sync_logs() {
+		global $wpdb;
+		$actions_table = $wpdb->prefix . 'actionscheduler_actions';
+		$logs_table    = $wpdb->prefix . 'actionscheduler_logs';
+
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $actions_table ) ) !== $actions_table ) {
+			return array(
+				'status'  => 'error',
+				'message' => __( 'Action Scheduler is not active.', 'woocommerce-es' ),
+			);
+		}
+
+		$hook_labels = array();
+		foreach ( self::get_cron_periods() as $period ) {
+			$hook_labels[ $period['cron'] ] = $period['display'];
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name from prefix.
+		$action_rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id, hook, status, scheduled_date_gmt, last_attempt_gmt
+				 FROM {$actions_table}
+				 WHERE hook LIKE %s
+				 ORDER BY scheduled_date_gmt DESC
+				 LIMIT 25",
+				'conecom_sync_%'
+			),
+			ARRAY_A
+		);
+
+		if ( empty( $action_rows ) ) {
+			return array(
+				'status'  => 'success',
+				'actions' => array(),
+			);
+		}
+
+		$action_ids = implode( ',', array_map( 'intval', array_column( $action_rows, 'id' ) ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table names from prefix, IDs intval'd.
+		$log_rows = $wpdb->get_results(
+			"SELECT action_id, message, log_date_gmt
+			 FROM {$logs_table}
+			 WHERE action_id IN ({$action_ids})
+			 ORDER BY log_date_gmt ASC",
+			ARRAY_A
+		);
+
+		$logs_by_action = array();
+		foreach ( $log_rows as $log ) {
+			$logs_by_action[ $log['action_id'] ][] = array(
+				'message' => $log['message'],
+				'date'    => get_date_from_gmt( $log['log_date_gmt'], get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ),
+			);
+		}
+
+		$actions = array();
+		foreach ( $action_rows as $row ) {
+			$actions[] = array(
+				'id'             => $row['id'],
+				'hook'           => $row['hook'],
+				'hook_label'     => $hook_labels[ $row['hook'] ] ?? $row['hook'],
+				'status'         => $row['status'],
+				'scheduled_date' => get_date_from_gmt( $row['scheduled_date_gmt'], get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ),
+				'last_attempt'   => ! empty( $row['last_attempt_gmt'] ) ? get_date_from_gmt( $row['last_attempt_gmt'], get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) : '',
+				'logs'           => $logs_by_action[ $row['id'] ] ?? array(),
+			);
+		}
+
+		return array(
+			'status'  => 'success',
+			'actions' => $actions,
+		);
+	}
 }

--- a/includes/Helpers/CRON.php
+++ b/includes/Helpers/CRON.php
@@ -57,7 +57,7 @@ class CRON {
 
 		// Get ALL products from API.
 		$products       = array();
-		$api_pagination = ! empty( $options['api_pagination'] ) ? (int) $options['api_pagination'] : false;
+		$api_pagination = defined( 'CONECOM_SYNC_PRODUCTS_PER_BATCH' ) ? CONECOM_SYNC_PRODUCTS_PER_BATCH : 50;
 		if ( $api_pagination ) {
 			$sync_loop = 0;
 
@@ -124,7 +124,7 @@ class CRON {
 		}
 		// Method with table sync.
 		global $wpdb;
-		$limit = isset( $settings['sync_num'] ) ? (int) $settings['sync_num'] : 50;
+		$limit = defined( 'CONECOM_SYNC_PRODUCTS_PER_BATCH' ) ? CONECOM_SYNC_PRODUCTS_PER_BATCH : 50;
 
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
@@ -221,7 +221,8 @@ class CRON {
 	 */
 	public static function send_sync_ended_products( $settings, $table_sync, $option_name, $option_prefix ) {
 		global $wpdb;
-		$send_email  = isset( $settings['sync_email'] ) ? strval( $settings['sync_email'] ) : 'yes';
+		$alerts      = get_option( 'connect_ecommerce_alerts', array() );
+		$send_email  = isset( $alerts['alert_product_synced'] ) ? strval( $alerts['alert_product_synced'] ) : 'no';
 		$total_count = $wpdb->get_var( "SELECT COUNT(*) FROM $table_sync WHERE synced = 1" );
 
 		if ( $total_count > 0 && 'yes' === $send_email ) {

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -1279,7 +1279,7 @@ class PROD {
 	 * @return array Import statistics.
 	 */
 	public static function get_import_stats( $connapi_erp, $options, $settings = array() ) {
-		if ( empty( $connapi_erp ) || ! method_exists( $connapi_erp, 'get_all_product_skus' ) ) {
+		if ( ! $connapi_erp || ! method_exists( $connapi_erp, 'get_all_product_skus' ) ) {
 			return array(
 				'status'  => 'error',
 				'message' => __( 'Connector does not support import statistics', 'woocommerce-es' ),

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -1278,7 +1278,7 @@ class PROD {
 	 * @param array  $options Plugin options.
 	 * @return array Import statistics.
 	 */
-	public static function get_import_stats( $connapi_erp, $options ) {
+	public static function get_import_stats( $connapi_erp, $options, $settings = array() ) {
 		if ( empty( $connapi_erp ) || ! method_exists( $connapi_erp, 'get_all_product_skus' ) ) {
 			return array(
 				'status'  => 'error',
@@ -1306,9 +1306,10 @@ class PROD {
 			);
 		}
 
-		// Normalize API result: array of SKUs or array of items with 'sku' (and optionally 'last_updated').
+		// Normalize API result: array of SKUs or array of items with 'sku' (and optionally 'last_updated', 'tags').
 		$api_skus         = array();
 		$api_skus_updated = array();
+		$api_skus_tags    = array();
 		if ( isset( $api_result['data'] ) && is_array( $api_result['data'] ) ) {
 			$raw = $api_result['data'];
 		} elseif ( is_array( $api_result ) ) {
@@ -1321,12 +1322,39 @@ class PROD {
 			if ( is_string( $item ) ) {
 				$api_skus[ $item ] = true;
 			} elseif ( is_array( $item ) && ! empty( $item['sku'] ) ) {
-				$sku = $item['sku'];
+				$sku              = $item['sku'];
 				$api_skus[ $sku ] = true;
 				if ( ! empty( $item['last_updated'] ) ) {
 					$api_skus_updated[ $sku ] = $item['last_updated'];
 				}
+				if ( ! empty( $item['tags'] ) ) {
+					$api_skus_tags[ $sku ] = (array) $item['tags'];
+				}
 			}
+		}
+
+		$api_total_count = count( $api_skus );
+
+		// Apply tag filter if configured (mirrors PROD::filter_product() logic).
+		$filter_tag = ! empty( $settings['filter'] ) ? $settings['filter'] : '';
+		if ( ! empty( $filter_tag ) ) {
+			$tags_option           = array_map( 'sanitize_text_field', array_map( 'trim', explode( ',', $filter_tag ) ) );
+			$filtered_skus         = array();
+			$filtered_skus_updated = array();
+
+			foreach ( $api_skus as $sku => $dummy ) {
+				$product_tags = isset( $api_skus_tags[ $sku ] ) ? $api_skus_tags[ $sku ] : array();
+				$product_tags = array_map( 'sanitize_text_field', array_map( 'trim', (array) $product_tags ) );
+				if ( ! empty( array_intersect( $tags_option, $product_tags ) ) ) {
+					$filtered_skus[ $sku ] = true;
+					if ( isset( $api_skus_updated[ $sku ] ) ) {
+						$filtered_skus_updated[ $sku ] = $api_skus_updated[ $sku ];
+					}
+				}
+			}
+
+			$api_skus         = $filtered_skus;
+			$api_skus_updated = $filtered_skus_updated;
 		}
 
 		$api_count = count( $api_skus );
@@ -1364,7 +1392,9 @@ class PROD {
 		return array(
 			'status'          => 'success',
 			'api_count'       => $api_count,
+			'api_total_count' => $api_total_count,
 			'available_count' => $api_count,
+			'filter_tag'      => $filter_tag,
 			'wp_count'        => $wp_count,
 			'import_count'    => $import_count,
 			'new_count'       => $new_count,

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -451,6 +451,16 @@ class PROD {
 		// Save ERP ID.
 		$product->update_meta_data( 'connect_ecommerce_id', $item['id'] );
 
+		// Save last updated date from API (timestamp) for import stats; fallback to current time.
+		$updated_ts = null;
+		if ( ! empty( $item['last_updated'] ) ) {
+			$updated_ts = is_numeric( $item['last_updated'] ) ? (int) $item['last_updated'] : strtotime( $item['last_updated'] );
+		}
+		if ( empty( $updated_ts ) || $updated_ts <= 0 ) {
+			$updated_ts = current_time( 'timestamp' );
+		}
+		$product->update_meta_data( 'conecom_updated', $updated_ts );
+
 		// Set properties and save.
 		$product->set_props( $product_props );
 		$product->save();
@@ -825,6 +835,52 @@ class PROD {
 			}
 		}
 		return $custom_fields;
+	}
+
+	/**
+	 * Gets WooCommerce product SKUs and last modified for import stats.
+	 * Only products with connect_ecommerce_id (linked to connector) are returned.
+	 * Uses conecom_updated (timestamp) when set, else post_modified.
+	 *
+	 * @return array Associative array sku => [ 'post_id' => int, 'last_modified' => 'Y-m-d H:i:s' ].
+	 */
+	public static function get_woocommerce_product_data_for_import_stats() {
+		global $wpdb;
+		$meta_link    = 'connect_ecommerce_id';
+		$meta_sku     = '_sku';
+		$meta_updated = 'conecom_updated';
+		// Products with connect_ecommerce_id, SKU, and conecom_updated or post_modified for comparison.
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT P.ID AS post_id, P.post_modified AS post_modified,
+				PM_sku.meta_value AS sku, PM_updated.meta_value AS conecom_updated
+				FROM {$wpdb->posts} AS P
+				INNER JOIN {$wpdb->postmeta} AS PM_link ON PM_link.post_id = P.ID AND PM_link.meta_key = %s
+				INNER JOIN {$wpdb->postmeta} AS PM_sku ON PM_sku.post_id = P.ID AND PM_sku.meta_key = %s
+				LEFT JOIN {$wpdb->postmeta} AS PM_updated ON PM_updated.post_id = P.ID AND PM_updated.meta_key = %s
+				WHERE P.post_type IN ( 'product', 'product_variation' )
+				AND P.post_status != 'trash'
+				AND PM_sku.meta_value != ''",
+				$meta_link,
+				$meta_sku,
+				$meta_updated
+			),
+			ARRAY_A
+		);
+		$data = array();
+		if ( ! empty( $results ) ) {
+			foreach ( $results as $row ) {
+				$sku = $row['sku'];
+				$ts  = ! empty( $row['conecom_updated'] ) && is_numeric( $row['conecom_updated'] )
+					? (int) $row['conecom_updated']
+					: null;
+				$data[ $sku ] = array(
+					'post_id'       => (int) $row['post_id'],
+					'last_modified' => $ts ? gmdate( 'Y-m-d H:i:s', $ts ) : $row['post_modified'],
+				);
+			}
+		}
+		return $data;
 	}
 
 	/**
@@ -1213,5 +1269,107 @@ class PROD {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * Get import statistics (only when connector has get_all_product_skus).
+	 *
+	 * @param object $connapi_erp Connector API object.
+	 * @param array  $options Plugin options.
+	 * @return array Import statistics.
+	 */
+	public static function get_import_stats( $connapi_erp, $options ) {
+		if ( empty( $connapi_erp ) || ! method_exists( $connapi_erp, 'get_all_product_skus' ) ) {
+			return array(
+				'status'  => 'error',
+				'message' => __( 'Connector does not support import statistics', 'woocommerce-es' ),
+			);
+		}
+
+		$transient_key = 'conecom_all_product_skus_' . sanitize_key( $options['slug'] );
+		$api_result    = get_transient( $transient_key );
+		if ( false === $api_result ) {
+			$api_result = $connapi_erp->get_all_product_skus();
+			if ( ! isset( $api_result['status'] ) || 'error' !== $api_result['status'] ) {
+				set_transient( $transient_key, $api_result, HOUR_IN_SECONDS );
+			}
+		}
+
+		// Accept 'error' as failure; 'ok' or 'success' (e.g. connect-woocommerce-neo) as success.
+		if ( isset( $api_result['status'] ) && 'error' === $api_result['status'] ) {
+			$message = isset( $api_result['message'] ) && ! empty( $api_result['message'] )
+				? $api_result['message']
+				: __( 'Error fetching product SKUs from API', 'woocommerce-es' );
+			return array(
+				'status'  => 'error',
+				'message' => $message,
+			);
+		}
+
+		// Normalize API result: array of SKUs or array of items with 'sku' (and optionally 'last_updated').
+		$api_skus         = array();
+		$api_skus_updated = array();
+		if ( isset( $api_result['data'] ) && is_array( $api_result['data'] ) ) {
+			$raw = $api_result['data'];
+		} elseif ( is_array( $api_result ) ) {
+			$raw = $api_result;
+		} else {
+			$raw = array();
+		}
+
+		foreach ( $raw as $item ) {
+			if ( is_string( $item ) ) {
+				$api_skus[ $item ] = true;
+			} elseif ( is_array( $item ) && ! empty( $item['sku'] ) ) {
+				$sku = $item['sku'];
+				$api_skus[ $sku ] = true;
+				if ( ! empty( $item['last_updated'] ) ) {
+					$api_skus_updated[ $sku ] = $item['last_updated'];
+				}
+			}
+		}
+
+		$api_count = count( $api_skus );
+		$api_ids   = array_keys( $api_skus );
+
+		$wp_products = self::get_woocommerce_product_data_for_import_stats();
+		$wp_count    = count( $wp_products );
+		$wp_skus     = array_keys( $wp_products );
+
+		$new_properties = array_diff( $api_ids, $wp_skus );
+		$new_count      = count( $new_properties );
+
+		$outdated_count = 0;
+		foreach ( $wp_products as $sku => $wp_data ) {
+			if ( ! isset( $api_skus[ $sku ] ) ) {
+				continue;
+			}
+			$api_date = isset( $api_skus_updated[ $sku ] ) ? $api_skus_updated[ $sku ] : null;
+			$wp_date  = isset( $wp_data['last_modified'] ) ? $wp_data['last_modified'] : null;
+			if ( empty( $api_date ) || empty( $wp_date ) ) {
+				continue;
+			}
+			$api_ts = is_numeric( $api_date ) ? (int) $api_date : strtotime( $api_date );
+			$wp_ts  = is_numeric( $wp_date ) ? (int) $wp_date : strtotime( $wp_date );
+			if ( $api_ts > 0 && $wp_ts > 0 && $api_ts > $wp_ts ) {
+				++$outdated_count;
+			}
+		}
+
+		$import_count = $new_count + $outdated_count;
+
+		$to_delete    = array_diff( $wp_skus, $api_ids );
+		$delete_count = count( $to_delete );
+
+		return array(
+			'status'          => 'success',
+			'api_count'       => $api_count,
+			'available_count' => $api_count,
+			'wp_count'        => $wp_count,
+			'import_count'    => $import_count,
+			'new_count'       => $new_count,
+			'outdated_count'  => $outdated_count,
+			'delete_count'    => $delete_count,
+		);
 	}
 }

--- a/includes/assets/admin-import.css
+++ b/includes/assets/admin-import.css
@@ -1,0 +1,254 @@
+/**
+ * Admin Import Styles
+ *
+ * Styles for the product import page when get_all_product_skus is available.
+ *
+ * @package WooCommerce_ES
+ */
+
+/* Statistics Cards */
+.conecom-import-stats {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+	gap: 20px;
+	margin: 20px 0 30px;
+}
+
+.conecom-stat-card {
+	background: white;
+	border: 1px solid #c3c4c7;
+	border-radius: 8px;
+	padding: 20px;
+	display: flex;
+	align-items: center;
+	gap: 15px;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+	transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.conecom-stat-card:hover {
+	transform: translateY(-2px);
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
+}
+
+.conecom-stat-icon {
+	width: 50px;
+	height: 50px;
+	border-radius: 8px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+}
+
+.conecom-icon-api {
+	background: #e8f4fd;
+	color: #0073aa;
+}
+
+.conecom-icon-wp {
+	background: #f0f0f1;
+	color: #2c3338;
+}
+
+.conecom-icon-import {
+	background: #ecf7ed;
+	color: #00a32a;
+}
+
+.conecom-icon-delete {
+	background: #fcf0f1;
+	color: #d63638;
+}
+
+.conecom-stat-icon .dashicons {
+	font-size: 28px;
+	width: 28px;
+	height: 28px;
+}
+
+.conecom-stat-content {
+	flex: 1;
+}
+
+.conecom-stat-value {
+	font-size: 32px;
+	font-weight: 700;
+	line-height: 1.2;
+	color: #1d2327;
+}
+
+.conecom-stat-label {
+	font-size: 13px;
+	font-weight: 600;
+	color: #50575e;
+	margin-top: 5px;
+}
+
+.conecom-stat-sublabel {
+	font-size: 12px;
+	color: #787c82;
+	margin-top: 2px;
+}
+
+.conecom-stat-card.loading .conecom-stat-value {
+	opacity: 0.5;
+}
+
+/* Two columns */
+.conecom-two-columns {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 30px;
+	margin: 20px 0;
+}
+
+@media (max-width: 782px) {
+	.conecom-two-columns {
+		grid-template-columns: 1fr;
+	}
+}
+
+.conecom-cron-logs h3,
+.conecom-manual-import h3 {
+	margin-top: 0;
+}
+
+/* Import controls */
+.connwoo-sync-with-stats .import-button-wrapper {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 10px;
+	margin-bottom: 15px;
+}
+
+.connwoo-sync-with-stats #import-mode {
+	height: 40px;
+	padding: 0 12px;
+	font-size: 14px;
+	border: 1px solid #2271b1;
+	border-radius: 3px;
+	background: white;
+	color: #2271b1;
+	cursor: pointer;
+	min-width: 180px;
+	line-height: 38px;
+}
+
+.connwoo-sync-with-stats #import-mode:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.connwoo-sync-with-stats .import-button-wrapper .button {
+	height: 40px;
+	padding: 0 16px;
+	font-size: 14px;
+	line-height: 38px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	box-sizing: border-box;
+}
+
+.connwoo-sync-with-stats #refresh_stats .dashicons {
+	font-size: 20px;
+	width: 20px;
+	height: 20px;
+	margin-right: 2px;
+}
+
+.connwoo-sync-with-stats .spinner {
+	float: none;
+	margin: 0;
+	display: none;
+}
+
+.connwoo-sync-with-stats .spinner.is-active {
+	display: block;
+	visibility: visible;
+}
+
+/* Log container with tabs */
+.conecom-log-container {
+	margin-top: 25px;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	background: #fff;
+}
+
+.conecom-log-tabs {
+	display: flex;
+	border-bottom: 1px solid #c3c4c7;
+	background: #f0f0f1;
+}
+
+.conecom-tab-button {
+	padding: 12px 20px;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	font-size: 14px;
+	color: #50575e;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.conecom-tab-button:hover {
+	color: #1d2327;
+}
+
+.conecom-tab-button.active {
+	background: #fff;
+	color: #2271b1;
+	font-weight: 600;
+	border-bottom: 2px solid #fff;
+	margin-bottom: -1px;
+}
+
+.conecom-tab-content {
+	padding: 15px;
+}
+
+.conecom-tab-pane {
+	display: none;
+}
+
+.conecom-tab-pane.active {
+	display: block;
+}
+
+.connwoo-sync-with-stats #logwrapper {
+	margin-top: 0;
+	padding: 0;
+}
+
+.connwoo-sync-with-stats #loglist {
+	max-height: 400px;
+	overflow-y: auto;
+	background: #f9f9f9;
+	padding: 10px;
+	border-radius: 3px;
+}
+
+.connwoo-sync-with-stats #loglist p {
+	margin: 5px 0;
+	padding: 5px 10px;
+	border-left: 3px solid #0073aa;
+}
+
+.connwoo-sync-with-stats #loglist p.odd {
+	background: #f0f0f1;
+}
+
+.connwoo-sync-with-stats #loglist p.even {
+	background: #fff;
+}
+
+.connwoo-sync-with-stats #loglist p.error {
+	border-left-color: #d63638;
+	background: #fcf0f1;
+}

--- a/includes/assets/sync-import.js
+++ b/includes/assets/sync-import.js
@@ -1,12 +1,13 @@
 function syncManualItems( element, action, loop = 0 ) {
 	element.classList.add('disabled');
 	element.innerHTML = ConEcom_ajaxAction.label_syncing + ' <span class="spinner is-active"></span>';
-	const productAI = document.querySelector('select[name="connwoo-sync-product-ai"]')?.value || '';
+	const productAI = document.querySelector('select[name="connwoo-sync-product-ai"]')?.value || document.querySelector('#connect_ecommerce_ai_stats')?.value || '';
 
 	const isOdd = number => number % 2 !== 0;
-	class_task = isOdd(loop) ? 'odd' : 'even';
-	
-	// AJAX request.
+	var class_task = isOdd(loop) ? 'odd' : 'even';
+
+	var body = 'action=' + action + '&nonce=' + ConEcom_ajaxAction.nonce + '&loop=' + loop + '&product_ai=' + productAI;
+
 	fetch( ConEcom_ajaxAction.url, {
 		method: 'POST',
 		credentials: 'same-origin',
@@ -14,9 +15,9 @@ function syncManualItems( element, action, loop = 0 ) {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			'Cache-Control': 'no-cache',
 		},
-		body: 'action=' + action + '&nonce=' + ConEcom_ajaxAction.nonce + '&loop=' + loop + '&product_ai=' + productAI,
+		body: body,
 	})
-	.then( (resp) => resp.json() )
+	.then( function(resp) { return resp.json(); } )
 	.then( function(results) {
 		if ( results.success ) {
 			if ( ! results.data.finish ) {
@@ -24,23 +25,124 @@ function syncManualItems( element, action, loop = 0 ) {
 			} else {
 				element.classList.remove('disabled');
 				element.innerHTML = ConEcom_ajaxAction.label_sync;
-				results.data.message = results.data.message + ConEcom_ajaxAction.label_sync_complete;
+				if ( results.data.message ) {
+					results.data.message = results.data.message + ConEcom_ajaxAction.label_sync_complete;
+				}
 			}
 		} else {
 			element.classList.remove('disabled');
 			element.innerHTML = ConEcom_ajaxAction.label_sync;
 		}
-		// Message.
-		if ( results.data.message != undefined ){
-			progressElement = document.createElement('p');
+		if ( results.data && results.data.message !== undefined ) {
+			var progressElement = document.createElement('p');
 			progressElement.className = class_task;
-			document.querySelector('#logwrapper #loglist').appendChild(progressElement);
-			progressElement.innerHTML = results.data.message;
+			var loglist = document.querySelector('#logwrapper #loglist');
+			if ( loglist ) {
+				progressElement.innerHTML = results.data.message;
+				loglist.appendChild(progressElement);
+			}
 		}
-		const loglist = document.querySelector('#logwrapper #loglist');
-		loglist.scrollTo({ top: loglist.scrollHeight, behavior: "smooth" });
+		var loglist = document.querySelector('#logwrapper #loglist');
+		if ( loglist ) {
+			loglist.scrollTo({ top: loglist.scrollHeight, behavior: 'smooth' });
+		}
 	})
-	.catch(err => console.log(err));
+	.catch(function(err) { console.log(err); });
+}
+
+/**
+ * Manual sync with mode (updated/all) and pagination. Used when get_all_product_skus exists.
+ */
+function syncManualItemsWithMode( element, action, loop, pagination ) {
+	var importMode = document.getElementById('import-mode');
+	var mode = importMode ? importMode.value : 'all';
+	var refreshButton = document.getElementById('refresh_stats');
+	var spinner = element.parentElement ? element.parentElement.querySelector('.spinner') : null;
+
+	if ( loop === 0 ) {
+		var manualTabButton = document.querySelector('.conecom-tab-button[data-tab="manual"]');
+		if ( manualTabButton ) {
+			manualTabButton.click();
+		}
+		var loglist = document.querySelector('#logwrapper #loglist');
+		if ( loglist ) {
+			loglist.innerHTML = '';
+		}
+	}
+
+	element.disabled = true;
+	element.textContent = ConEcom_ajaxAction.label_syncing;
+	if ( importMode ) { importMode.disabled = true; }
+	if ( refreshButton ) { refreshButton.disabled = true; }
+	if ( spinner ) { spinner.classList.add('is-active'); }
+
+	var productAI = document.querySelector('select[name="connwoo-sync-product-ai"]')?.value || document.querySelector('#connect_ecommerce_ai_stats')?.value || '';
+	var isOdd = function(n) { return n % 2 !== 0; };
+	var class_task = isOdd(loop) ? 'odd' : 'even';
+
+	var body = 'action=' + action + '&nonce=' + ConEcom_ajaxAction.nonce + '&loop=' + loop + '&product_ai=' + productAI + '&mode=' + encodeURIComponent(mode) + '&pagination=' + (pagination || 100);
+
+	fetch( ConEcom_ajaxAction.url, {
+		method: 'POST',
+		credentials: 'same-origin',
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded',
+			'Cache-Control': 'no-cache',
+		},
+		body: body,
+	})
+	.then( function(resp) { return resp.json(); } )
+	.then( function(results) {
+		if ( results.success ) {
+			if ( results.data && results.data.message ) {
+				var progressElement = document.createElement('p');
+				progressElement.className = class_task;
+				var loglist = document.querySelector('#logwrapper #loglist');
+				if ( loglist ) {
+					progressElement.innerHTML = results.data.message;
+					loglist.appendChild(progressElement);
+				}
+			}
+			if ( ! results.data.finish ) {
+				syncManualItemsWithMode(element, action, results.data.loop, pagination);
+			} else {
+				element.disabled = false;
+				element.textContent = ConEcom_ajaxAction.label_sync;
+				if ( importMode ) { importMode.disabled = false; }
+				if ( refreshButton ) { refreshButton.disabled = false; }
+				if ( spinner ) { spinner.classList.remove('is-active'); }
+				if ( typeof loadImportStats === 'function' ) {
+					loadImportStats();
+				}
+			}
+		} else {
+			element.disabled = false;
+			element.textContent = ConEcom_ajaxAction.label_sync;
+			if ( importMode ) { importMode.disabled = false; }
+			if ( refreshButton ) { refreshButton.disabled = false; }
+			if ( spinner ) { spinner.classList.remove('is-active'); }
+			if ( results.data && results.data.message ) {
+				var errEl = document.createElement('p');
+				errEl.className = 'error';
+				errEl.style.color = 'red';
+				errEl.innerHTML = results.data.message;
+				var loglist = document.querySelector('#logwrapper #loglist');
+				if ( loglist ) { loglist.appendChild(errEl); }
+			}
+		}
+		var loglist = document.querySelector('#logwrapper #loglist');
+		if ( loglist ) {
+			loglist.scrollTo({ top: loglist.scrollHeight, behavior: 'smooth' });
+		}
+	})
+	.catch(function(err) {
+		console.error('Import error:', err);
+		element.disabled = false;
+		element.textContent = ConEcom_ajaxAction.label_sync;
+		if ( importMode ) { importMode.disabled = false; }
+		if ( refreshButton ) { refreshButton.disabled = false; }
+		if ( spinner ) { spinner.classList.remove('is-active'); }
+	});
 }
 
 function syncProductERP( element, action, product_erp_id = 0, product_sku = '', product_id = 0 ) {

--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ $products = [
 				'content' => Content of image,
 				'content_type' => Content type from image,
 			],
+		'last_updated' => Date from last updated from the product.
 		rates: array(4)
 			0: array(3)
 			id: "65f40aaf178216df3a054762"

--- a/readme.txt
+++ b/readme.txt
@@ -219,6 +219,12 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 == Changelog ==
 
 = n.e.x.t =
+* **Sync settings refactor:** Removed Synchronization > Automate tab; sync frequency ("When do you want to sync?") is now set on Synchronization > Products in the Automatic Sync section.
+* **Sync batch size:** Removed "How many products do you want to sync each time?"; batch size is now a fixed constant (50 products per run).
+* **Alerts:** "Email when all products are synced" moved to Settings > Alerts as "Enable Alerts Product synced" (global option).
+* **Product sync stats:** First stat label changed to "Available in [ERP name]" (e.g. Holded); when a tag filter is active, shows filtered count plus "Total" (unfiltered) in sublabel.
+* **Product sync stats:** Stats now respect the tag filter (filter products by tags) so counts match what is actually synced.
+* **Automatic Sync tab:** Replaced static message with Action Scheduler log table showing recent conecom_sync_* runs (date, status, frequency, logs).
 * Enhancement: Improved import products from API. Stats now shows the number of products fetched from the API.
 * Enhancement: Added payment method status to payment method mapping.
 * Fixed: Variations now inherit parent tax class correctly by setting tax_class to "parent" on creation.

--- a/readme.txt
+++ b/readme.txt
@@ -219,6 +219,7 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 == Changelog ==
 
 = n.e.x.t =
+* Enhancement: Improved import products from API. Stats now shows the number of products fetched from the API.
 * Enhancement: Added payment method status to payment method mapping.
 * Fixed: Variations now inherit parent tax class correctly by setting tax_class to "parent" on creation.
 * Fixed: Tax class "parent" is preserved when products are re-synced/updated, preventing tax calculation inconsistencies.

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -5,7 +5,7 @@
  * Description:       Connects Ecommerce WooCommerce to ERPs and CRMs. Syncs products, customers, orders and stock. Includes EU VAT Compliance. Import European Taxes and check VAT compliance.
  * Author:            Closetechnology
  * Author URI:        https://close.technology/
- * Version:           3.3.3-beta.1
+ * Version:           3.3.3-beta.2
  * Requires PHP:      7.4
  * Requires at least: 6.3
  * Text Domain:       woocommerce-es
@@ -20,7 +20,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CONECOM_VERSION', '3.3.3-beta.1' );
+define( 'CONECOM_VERSION', '3.3.3-beta.2' );
 define( 'CONECOM_FILE', __FILE__ );
 define( 'CONECOM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONECOM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -24,6 +24,7 @@ define( 'CONECOM_VERSION', '3.3.3-beta.2' );
 define( 'CONECOM_FILE', __FILE__ );
 define( 'CONECOM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONECOM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+define( 'CONECOM_SYNC_PRODUCTS_PER_BATCH', 50 );
 define(
 	'CONECOM_VAT_FIELD_SLUGS',
 	array(

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -5,7 +5,7 @@
  * Description:       Connects Ecommerce WooCommerce to ERPs and CRMs. Syncs products, customers, orders and stock. Includes EU VAT Compliance. Import European Taxes and check VAT compliance.
  * Author:            Closetechnology
  * Author URI:        https://close.technology/
- * Version:           3.3.2
+ * Version:           3.3.3-beta.1
  * Requires PHP:      7.4
  * Requires at least: 6.3
  * Text Domain:       woocommerce-es
@@ -20,7 +20,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CONECOM_VERSION', '3.3.2' );
+define( 'CONECOM_VERSION', '3.3.3-beta.1' );
 define( 'CONECOM_FILE', __FILE__ );
 define( 'CONECOM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONECOM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
# Description

This PR refactors product sync settings and statistics: it removes the Automate tab, moves sync and alert options to clearer places, fixes sync statistics with tag filtering, and shows Action Scheduler logs for automatic sync.

Fixes #131

## Changes

- **Synchronization > Automate removed**
  - Removed the "Automate" sub-tab and its page under Synchronization.
  - Removed the automate settings section and its fields from the Settings API.

- **"When do you want to sync?" moved to Products**
  - Sync frequency is now configured in **Synchronization > Products**, in the "Automatic Sync (Cron)" block.
  - Inline form: label, select and "Save" button on the same line (flexbox).

- **Batch size set to constant**
  - New constant `CONECOM_SYNC_PRODUCTS_PER_BATCH` (50) in `woocommerce-es.php`.
  - Removed the "How many products do you want to sync each time?" field.
  - Replaced all uses of `api_pagination` / `sync_num` with this constant in Settings, Import_Products, CRON and CLI.
  - Removed `sync_num` and `sync_email` from connector defaults in `sanitize_fields_settings`.

- **"Enable Alerts Product synced" in Settings > Alerts**
  - New option in **Settings > Alerts**: "Enable Alerts Product synced" (Yes/No) with description "Receive an email when all products have been synced."
  - Stored in `connect_ecommerce_alerts['alert_product_synced']`.
  - `CRON::send_sync_ended_products()` now reads this option instead of connector `sync_email`; default is `no`.

- **Product sync statistics (tag filter and labels)**
  - First stat label changed from "Available in API" to "Available in {ERP name}" (e.g. "Available in Holded").
  - When a tag filter is set: show "Tag: …" and a small "Total: X" (unfiltered count).
  - Holded API `get_all_product_skus()` extended to return `tags` per product.
  - `PROD::get_import_stats()` accepts `$settings`, applies tag filter to API SKUs, and returns `api_total_count` and `filter_tag`; Import_Products passes settings and exposes these in the AJAX response.

- **Automatic Sync tab: Action Scheduler logs**
  - Replaced the static text "Automatic sync runs in the background. Check WooCommerce logs for details." with a table of recent Action Scheduler runs for `conecom_sync_*` hooks.
  - New AJAX action `connect_ecommerce_get_as_logs`; logic moved to `CRON::get_sync_logs()` (static). Table shows date, status, frequency label and last log; rows with multiple logs are expandable.

## Benefits

- Single place for sync frequency (Products page) and no separate Automate tab.
- Clearer Alerts section with product-sync email under Settings > Alerts.
- Fixed batch size (50) simplifies configuration and behaviour.
- Statistics reflect tag filtering and show ERP name and total unfiltered count.
- Admins can see automatic sync runs and logs without checking WooCommerce logs.

## Testing Instructions

1. **Sync frequency and Save button**
   - Go to **Connect Ecommerce > Synchronization > Products**.
   - In "Automatic Sync (Cron)", confirm "When do you want to sync?" and "Save" are on the same line.
   - Change the dropdown and click Save; confirm the value is saved and the page stays on Products.

2. **Automate tab removed**
   - Under Synchronization, confirm only "Products" and "Orders" sub-tabs exist (no "Automate").

3. **Enable Alerts Product synced**
   - Go to **Settings > Alerts**.
   - Confirm "Enable Alerts Product synced" (Yes/No) is present.
   - Set to Yes, save, run a full product sync (with table_sync connector); confirm the "all products synced" email is sent when sync finishes.

4. **Statistics with tag filter (Holded or connector with get_all_product_skus)**
   - Set a tag filter in Connection settings.
   - On Products page, click "Refresh Statistics".
   - Confirm first stat shows "Available in {ERP}" and, when filtered, the sublabel shows "Tag: …" and "Total: X".

5. **Action Scheduler logs**
   - Open **Synchronization > Products** and the "Automatic Sync" log tab.
   - Confirm a table of recent `conecom_sync_*` runs appears (or "No sync runs recorded yet").
   - Click a row with multiple log entries and confirm the detail row expands.

6. **Batch size**
   - Run a manual or CLI product import; confirm batches of 50 products (or connector’s API behaviour) and no setting for "how many products each time".

## Checklist

- [ ] Code follows WordPress Coding Standards
- [ ] Self-reviewed the code
- [ ] Added necessary comments
- [ ] No new linter errors