### PR TITLE
Add support for info-level alerts and improve alert messaging

### DIFF
--- a/includes/Helpers/ALERT.php
+++ b/includes/Helpers/ALERT.php
@@ -27,7 +27,7 @@ class ALERT {
 	 *
 	 * @return bool Success status.
 	 */
-	public static function send_alert( $subject, $message, $context = array() ) {
+	public static function send_alert( $subject, $message, $context = array(), $is_error = true ) {
 		$settings      = get_option( 'connect_ecommerce_alerts' );
 		$alert_method  = isset( $settings['alert_method'] ) ? $settings['alert_method'] : 'email';
 		$alert_enabled = isset( $settings['alert_enabled'] ) ? $settings['alert_enabled'] : 'no';
@@ -38,20 +38,30 @@ class ALERT {
 
 		// Log to WooCommerce logger always.
 		$logger = wc_get_logger();
-		$logger->error(
-			$subject . ': ' . $message,
-			array(
-				'source'  => 'connect-ecommerce-alerts',
-				'context' => $context,
-			)
-		);
+		if ( $is_error ) {
+			$logger->error(
+				$subject . ': ' . $message,
+				array(
+					'source'  => 'connect-ecommerce-alerts',
+					'context' => $context,
+				)
+			);
+		} else {
+			$logger->info(
+				$subject . ': ' . $message,
+				array(
+					'source'  => 'connect-ecommerce-alerts',
+					'context' => $context,
+				)
+			);
+		}
 
 		$result = false;
 
 		if ( 'email' === $alert_method ) {
-			$result = self::send_email_alert( $subject, $message, $context );
+			$result = self::send_email_alert( $subject, $message, $context, $is_error );
 		} elseif ( 'slack' === $alert_method ) {
-			$result = self::send_slack_alert( $subject, $message, $context );
+			$result = self::send_slack_alert( $subject, $message, $context, $is_error );
 		}
 
 		return $result;
@@ -66,13 +76,15 @@ class ALERT {
 	 *
 	 * @return bool Success status.
 	 */
-	private static function send_email_alert( $subject, $message, $context = array() ) {
+	private static function send_email_alert( $subject, $message, $context = array(), $is_error = true ) {
 		$settings      = get_option( 'connect_ecommerce_alerts' );
 		$email_address = isset( $settings['alert_email'] ) ? $settings['alert_email'] : get_option( 'admin_email' );
 
+		$border_color = $is_error ? '#dc3232' : '#46b450';
+
 		$body  = '<html><body>';
 		$body .= '<h2>' . esc_html( $subject ) . '</h2>';
-		$body .= '<div style="background: #f8f8f8; padding: 15px; margin: 10px 0; border-left: 4px solid #dc3232;">';
+		$body .= '<div style="background: #f8f8f8; padding: 15px; margin: 10px 0; border-left: 4px solid ' . esc_attr( $border_color ) . ';">';
 		$body .= wp_kses_post( $message );
 		$body .= '</div>';
 
@@ -103,7 +115,7 @@ class ALERT {
 	 *
 	 * @return bool Success status.
 	 */
-	private static function send_slack_alert( $subject, $message, $context = array() ) {
+	private static function send_slack_alert( $subject, $message, $context = array(), $is_error = true ) {
 		$settings    = get_option( 'connect_ecommerce_alerts' );
 		$webhook_url = isset( $settings['slack_webhook'] ) ? $settings['slack_webhook'] : '';
 
@@ -111,13 +123,15 @@ class ALERT {
 			return false;
 		}
 
+		$header_emoji = $is_error ? '🚨' : '✅';
+
 		// Build Slack message blocks.
 		$blocks = array(
 			array(
 				'type' => 'header',
 				'text' => array(
 					'type' => 'plain_text',
-					'text' => '🚨 ' . $subject,
+					'text' => $header_emoji . ' ' . $subject,
 				),
 			),
 			array(

--- a/includes/Helpers/ORDER.php
+++ b/includes/Helpers/ORDER.php
@@ -88,12 +88,10 @@ class ORDER {
 					'status'  => 'error',
 					'message' => $e->getMessage(),
 				);
-				// Send alert for order error.
-				ALERT::send_order_error_alert( $order_id, $e->getMessage() );
 			}
 		} else {
 			$result = array(
-				'status'  => 'error',
+				'status'  => 'ok',
 				'message' => $doctype . ' ' . __( 'num: ', 'woocommerce-es' ) . $ec_invoice_id,
 			);
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -229,7 +229,9 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 * Enhancement: Added payment method status to payment method mapping.
 * Fixed: Variations now inherit parent tax class correctly by setting tax_class to "parent" on creation.
 * Fixed: Tax class "parent" is preserved when products are re-synced/updated, preventing tax calculation inconsistencies.
-* Fixed: Plugin no longer shows alerts for successful order submissions to API - alerts now only appear on actual errors.
+* Fixed: Alert notifications (Slack, email) no longer fire with "Order Submission Error" title when an order was already synced to the ERP or submitted successfully. Previously the already-synced branch incorrectly returned `status: error`, triggering a false alert.
+* Fixed: Duplicate alert on order submission exception — alert was sent twice (once in catch block, once in post-try check); now sent only once.
+* Enhancement: Alert notifications now reflect actual severity — errors use 🚨 emoji and red border, informational/success notifications use ✅ and green border.
 * Enhancement: Added comprehensive test coverage for variation tax class inheritance and persistence on updates.
 * Enhancement: Improved order sync UI feedback - success messages are shown in green and auto-hide after 5 seconds, errors show alerts.
 * Fixed: Product importer now correctly detects end of paginated product list, preventing unnecessary API calls beyond last product.

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -5,7 +5,7 @@
  * Description:       Connects Ecommerce WooCommerce to ERPs and CRMs. Syncs products, customers, orders and stock. Includes EU VAT Compliance. Import European Taxes and check VAT compliance.
  * Author:            Closetechnology
  * Author URI:        https://close.technology/
- * Version:           3.3.3-beta.2
+ * Version:           3.3.3-beta.4
  * Requires PHP:      7.4
  * Requires at least: 6.3
  * Text Domain:       woocommerce-es
@@ -20,7 +20,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CONECOM_VERSION', '3.3.3-beta.2' );
+define( 'CONECOM_VERSION', '3.3.3-beta.4' );
 define( 'CONECOM_FILE', __FILE__ );
 define( 'CONECOM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONECOM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
## Summary
Enhanced the alert system to support both error and info-level notifications, allowing for more flexible alert categorization. This enables the system to distinguish between critical errors and informational messages while maintaining backward compatibility.

## Key Changes
- Added `$is_error` parameter to `send_alert()`, `send_email_alert()`, and `send_slack_alert()` methods (defaults to `true` for backward compatibility)
- Updated WooCommerce logger to use `error()` for errors and `info()` for informational messages based on the `$is_error` flag
- Modified email alert styling to use dynamic border color: red (#dc3232) for errors, green (#46b450) for info messages
- Updated Slack alert header emoji: 🚨 for errors, ✅ for info messages
- Removed redundant error alert call in `ORDER::create_invoice()` method
- Fixed status response in `ORDER::create_invoice()` from 'error' to 'ok' for successful invoice creation

## Implementation Details
- The `$is_error` parameter defaults to `true`, ensuring existing code continues to log alerts as errors without modification
- Email and Slack alert formatting now visually distinguishes between error and info alerts through color and emoji indicators
- All alert methods properly propagate the `$is_error` flag through the call chain

https://claude.ai/code/session_01LnVw4U2FmpxueWBNVGRHNk