### PR TITLE
Preserve subscription product types during ERP sync

### DIFF
--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -586,6 +586,11 @@ class PROD {
 		$import_stock    = ! empty( $settings['stock'] ) ? $settings['stock'] : 'no';
 		$message         = '';
 
+		// Snapshot of variation IDs that existed before this sync — unlike
+		// $variations_item (consumed below as each variant is matched), this
+		// stays intact so newly added variants can still find a sibling to
+		// copy the subscription schedule from (see the variant loop below).
+		$existing_variation_ids = array();
 		if ( ! $is_new_product ) {
 			foreach ( $product->get_children() as $child_id ) {
 				// get an instance of the WC_Variation_product Object.
@@ -594,6 +599,7 @@ class PROD {
 					continue;
 				}
 				$variations_item[ $child_id ] = $variation_children->get_sku();
+				$existing_variation_ids[]     = $child_id;
 			}
 		}
 
@@ -615,8 +621,15 @@ class PROD {
 		foreach ( $item['variants'] as $variant ) {
 			$variation_id = 0; // default value.
 			if ( ! $is_new_product && ! empty( $variations_item ) && is_array( $variations_item ) ) {
-				$variation_id = array_search( $variant['sku'], $variations_item );
-				unset( $variations_item[ $variation_id ] );
+				// array_search() returns false (not 0) when the SKU isn't found among
+				// existing variations — normalize back to 0 so "0 === $variation_id"
+				// checks below correctly treat it as a new variation instead of silently
+				// never matching (false !== 0 under strict comparison).
+				$found_variation_id = array_search( $variant['sku'], $variations_item, true );
+				if ( false !== $found_variation_id ) {
+					$variation_id = $found_variation_id;
+					unset( $variations_item[ $variation_id ] );
+				}
 			}
 
 			if ( ! isset( $variant['categoryFields'] ) ) {
@@ -685,8 +698,11 @@ class PROD {
 				$subscription_price = ! empty( $price_sale_var ) ? $price_sale_var : $variation_price;
 				$variation->update_meta_data( '_subscription_price', $subscription_price );
 
-				// Copy the subscription schedule from the parent onto new variants so they
-				// inherit the merchant's billing cadence instead of WooCommerce defaults.
+				// Copy the subscription schedule onto new variants so they inherit the
+				// merchant's billing cadence instead of WooCommerce defaults. WC Subscriptions
+				// stores the schedule per-variation, not on the parent, so prefer an existing
+				// sibling variation as the source and only fall back to the parent's own meta
+				// (e.g. set directly on the product before any variations existed).
 				if ( 0 === $variation_id ) {
 					$schedule_keys = array(
 						'_subscription_period',
@@ -696,10 +712,14 @@ class PROD {
 						'_subscription_trial_period',
 						'_subscription_sign_up_fee',
 					);
+					$schedule_source = ! empty( $existing_variation_ids ) ? reset( $existing_variation_ids ) : $product_id;
 					foreach ( $schedule_keys as $meta_key ) {
-						$parent_value = get_post_meta( $product_id, $meta_key, true );
-						if ( '' !== $parent_value ) {
-							$variation->update_meta_data( $meta_key, $parent_value );
+						$schedule_value = get_post_meta( $schedule_source, $meta_key, true );
+						if ( '' === $schedule_value ) {
+							$schedule_value = get_post_meta( $product_id, $meta_key, true );
+						}
+						if ( '' !== $schedule_value ) {
+							$variation->update_meta_data( $meta_key, $schedule_value );
 						}
 					}
 				}
@@ -725,7 +745,12 @@ class PROD {
 				);
 				continue;
 			}
-			if ( $is_new_product ) {
+			if ( empty( $variation->get_sku( 'edit' ) ) ) {
+				// 'edit' context reads the variation's own raw value — get_sku()'s
+				// default 'view' context falls back to the parent SKU when empty,
+				// which would make this check always look non-empty.
+				// Covers brand-new products and new variants added to an existing
+				// product — both cases need the SKU set once, on creation.
 				$variation->set_sku( $variant['sku'] );
 			}
 

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -268,12 +268,24 @@ class PROD {
 
 		// Start.
 		try {
-			if ( 'simple' === $type ) {
-				$product = new \WC_Product( $product_id );
-			} elseif ( 'variable' === $type ) {
-				$product = new \WC_Product_Variable( $product_id );
-			} elseif ( 'pack' === $type ) {
-				$product = new \WC_Product( $product_id );
+			// Preserve subscription product types — ERP has no subscription concept.
+			$subscription_types = array( 'subscription', 'variable-subscription' );
+			if ( ! $is_new_product ) {
+				$existing_product = wc_get_product( $product_id );
+				if ( $existing_product && in_array( $existing_product->get_type(), $subscription_types, true ) ) {
+					$product = $existing_product;
+				}
+				unset( $existing_product );
+			}
+
+			if ( null === $product ) {
+				if ( 'simple' === $type ) {
+					$product = new \WC_Product( $product_id );
+				} elseif ( 'variable' === $type ) {
+					$product = new \WC_Product_Variable( $product_id );
+				} elseif ( 'pack' === $type ) {
+					$product = new \WC_Product( $product_id );
+				}
 			}
 		} catch ( \Exception $e ) {
 			return array(

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -651,6 +651,12 @@ class PROD {
 				}
 			}
 			$variation->set_props( $variation_props );
+
+			// For variable-subscription products, keep the subscription price in sync.
+			if ( 'variable-subscription' === $product->get_type() && ! empty( $variation_price ) ) {
+				$variation->update_meta_data( '_subscription_price', $variation_price );
+			}
+
 			// Stock.
 			if ( 'yes' === $import_stock && isset( $variant['stock'] ) ) {
 				$item_stock   = (int) $variant['stock'];

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -644,8 +644,12 @@ class PROD {
 				// array_search() returns false (not 0) when the SKU isn't found among
 				// existing variations — normalize back to 0 so "0 === $variation_id"
 				// checks below correctly treat it as a new variation instead of silently
-				// never matching (false !== 0 under strict comparison).
-				$found_variation_id = array_search( $variant['sku'], $variations_item, true );
+				// never matching (false !== 0 under strict comparison). Cast both sides
+				// to string first: ERPs that serialize numeric SKUs as JSON numbers give
+				// $variant['sku'] as an int, while get_sku() always returns a string.
+				$variant_sku_str        = (string) $variant['sku'];
+				$variations_item_lookup = array_map( 'strval', $variations_item );
+				$found_variation_id     = array_search( $variant_sku_str, $variations_item_lookup, true );
 				if ( false !== $found_variation_id ) {
 					$variation_id = $found_variation_id;
 					unset( $variations_item[ $variation_id ] );
@@ -749,8 +753,15 @@ class PROD {
 				$variation->set_manage_stock( false );
 				$variation->set_stock_status( 'instock' );
 			}
-			$variation_prevent_id = self::find_product( $variant['sku'] );
-			if ( ! empty( $variation_prevent_id ) ) {
+			// Check for a SKU collision with another product AND with another
+			// variation (find_product() defaults to post_type='product', which
+			// misses existing product_variation rows — set_sku() below would
+			// then throw WooCommerce's duplicate-SKU exception and abort the
+			// whole sync instead of skipping just this variant).
+			$duplicate_product_id   = self::find_product( $variant['sku'] );
+			$duplicate_variation_id = self::find_product( $variant['sku'], 'product_variation' );
+			$variation_prevent_id   = ! empty( $duplicate_product_id ) ? $duplicate_product_id : $duplicate_variation_id;
+			if ( ! empty( $variation_prevent_id ) && (int) $variation_prevent_id !== (int) $variation_id ) {
 				$message .= sprintf(
 					/* translators: %s: SKU */
 					__( 'Duplicated SKU: %s (not imported) ', 'woocommerce-es' ),

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -266,22 +266,31 @@ class PROD {
 		$product            = null;
 		$item_sku           = ! empty( $item['sku'] ) ? $item['sku'] : '';
 
+		// Preserve subscription product types — ERP has no subscription concept.
+		// Read the type directly from the taxonomy (not via wc_get_product, which may be cached),
+		// then restore it with wp_set_object_terms after every save so WooCommerce internals
+		// cannot overwrite it. Gate on ERP shape matching the subtype to avoid type mismatches:
+		// simple ERP item → subscription, variable ERP item → variable-subscription.
+		$preserved_sub_type = null;
+		if ( ! $is_new_product ) {
+			$existing_terms = get_the_terms( $product_id, 'product_type' );
+			$existing_type  = ( ! empty( $existing_terms ) && ! is_wp_error( $existing_terms ) )
+				? sanitize_title( current( $existing_terms )->name )
+				: '';
+			$is_simple_sub   = ( 'simple' === $type && 'subscription' === $existing_type );
+			$is_variable_sub = ( 'variable' === $type && 'variable-subscription' === $existing_type );
+			if ( $is_simple_sub || $is_variable_sub ) {
+				$preserved_sub_type = $existing_type;
+			}
+			unset( $existing_terms, $existing_type, $is_simple_sub, $is_variable_sub );
+		}
+
 		// Start.
 		try {
-			// Preserve subscription product types — ERP has no subscription concept.
-			// Only reuse the subscription object when the ERP shape matches the subtype:
-			// simple ERP item → subscription, variable ERP item → variable-subscription.
-			if ( ! $is_new_product ) {
-				$existing_product      = wc_get_product( $product_id );
-				$existing_type         = $existing_product ? $existing_product->get_type() : '';
-				$is_simple_sub_match   = ( 'simple' === $type && 'subscription' === $existing_type );
-				$is_variable_sub_match = ( 'variable' === $type && 'variable-subscription' === $existing_type );
-				if ( $is_simple_sub_match || $is_variable_sub_match ) {
-					$product = $existing_product;
-				}
-				unset( $existing_product, $existing_type, $is_simple_sub_match, $is_variable_sub_match );
+			if ( null !== $preserved_sub_type ) {
+				// Load via wc_get_product so the correct WC class is used for the sync.
+				$product = wc_get_product( $product_id ) ?: null;
 			}
-
 			if ( null === $product ) {
 				if ( 'simple' === $type ) {
 					$product = new \WC_Product( $product_id );
@@ -486,11 +495,18 @@ class PROD {
 		// Set properties and save.
 		$product->set_props( $product_props );
 		$product->save();
+
 		if ( 'pack' === $type ) {
 			// Only call taxonomy functions if taxonomy exists
 			if ( taxonomy_exists( 'product_type' ) ) {
 				wp_set_object_terms( $product_id, 'woosb', 'product_type' );
 			}
+		}
+
+		// Restore subscription type after all saves — WooCommerce may reset the taxonomy
+		// term during save when the WC class does not match the registered subscription type.
+		if ( null !== $preserved_sub_type && taxonomy_exists( 'product_type' ) ) {
+			wp_set_object_terms( $product_id, $preserved_sub_type, 'product_type' );
 		}
 
 		return array(

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -269,20 +269,18 @@ class PROD {
 		// Preserve subscription product types — ERP has no subscription concept.
 		// Read the type directly from the taxonomy (not via wc_get_product, which may be cached),
 		// then restore it with wp_set_object_terms after every save so WooCommerce internals
-		// cannot overwrite it. Gate on ERP shape matching the subtype to avoid type mismatches:
-		// simple ERP item → subscription, variable ERP item → variable-subscription.
+		// cannot overwrite it. Any ERP shape (simple or variable) preserves the subscription
+		// type because the ERP may legitimately change shape while the subscription remains.
 		$preserved_sub_type = null;
 		if ( ! $is_new_product ) {
 			$existing_terms = get_the_terms( $product_id, 'product_type' );
 			$existing_type  = ( ! empty( $existing_terms ) && ! is_wp_error( $existing_terms ) )
 				? sanitize_title( current( $existing_terms )->name )
 				: '';
-			$is_simple_sub   = ( 'simple' === $type && 'subscription' === $existing_type );
-			$is_variable_sub = ( 'variable' === $type && 'variable-subscription' === $existing_type );
-			if ( $is_simple_sub || $is_variable_sub ) {
+			if ( in_array( $existing_type, array( 'subscription', 'variable-subscription' ), true ) ) {
 				$preserved_sub_type = $existing_type;
 			}
-			unset( $existing_terms, $existing_type, $is_simple_sub, $is_variable_sub );
+			unset( $existing_terms, $existing_type );
 		}
 
 		// Start.
@@ -492,6 +490,14 @@ class PROD {
 		}
 		$product->update_meta_data( 'conecom_updated', $updated_ts );
 
+		// For simple subscription products, keep _subscription_price in sync.
+		// Use sale price as the recurring amount when active (WC Subscriptions behaviour).
+		if ( 'subscription' === $preserved_sub_type ) {
+			$price_sale_sub     = self::get_sale_price( $item, $settings );
+			$subscription_price = ! empty( $price_sale_sub ) ? $price_sale_sub : self::get_rate_price( $item, $rate_id );
+			$product->update_meta_data( '_subscription_price', $subscription_price );
+		}
+
 		// Set properties and save.
 		$product->set_props( $product_props );
 		$product->save();
@@ -672,9 +678,31 @@ class PROD {
 			}
 			$variation->set_props( $variation_props );
 
-			// For variable-subscription products, keep the subscription price in sync.
-			if ( 'variable-subscription' === $product->get_type() && ! empty( $variation_price ) ) {
-				$variation->update_meta_data( '_subscription_price', $variation_price );
+			// For variable-subscription products, sync subscription price and schedule.
+			if ( 'variable-subscription' === $product->get_type() ) {
+				// Use sale price as the recurring amount when active (WC Subscriptions behaviour).
+				$price_sale_var     = self::get_sale_price( $variant, $settings );
+				$subscription_price = ! empty( $price_sale_var ) ? $price_sale_var : $variation_price;
+				$variation->update_meta_data( '_subscription_price', $subscription_price );
+
+				// Copy the subscription schedule from the parent onto new variants so they
+				// inherit the merchant's billing cadence instead of WooCommerce defaults.
+				if ( 0 === $variation_id ) {
+					$schedule_keys = array(
+						'_subscription_period',
+						'_subscription_period_interval',
+						'_subscription_length',
+						'_subscription_trial_length',
+						'_subscription_trial_period',
+						'_subscription_sign_up_fee',
+					);
+					foreach ( $schedule_keys as $meta_key ) {
+						$parent_value = get_post_meta( $product_id, $meta_key, true );
+						if ( '' !== $parent_value ) {
+							$variation->update_meta_data( $meta_key, $parent_value );
+						}
+					}
+				}
 			}
 
 			// Stock.

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -269,13 +269,17 @@ class PROD {
 		// Start.
 		try {
 			// Preserve subscription product types — ERP has no subscription concept.
-			$subscription_types = array( 'subscription', 'variable-subscription' );
+			// Only reuse the subscription object when the ERP shape matches the subtype:
+			// simple ERP item → subscription, variable ERP item → variable-subscription.
 			if ( ! $is_new_product ) {
-				$existing_product = wc_get_product( $product_id );
-				if ( $existing_product && in_array( $existing_product->get_type(), $subscription_types, true ) ) {
+				$existing_product      = wc_get_product( $product_id );
+				$existing_type         = $existing_product ? $existing_product->get_type() : '';
+				$is_simple_sub_match   = ( 'simple' === $type && 'subscription' === $existing_type );
+				$is_variable_sub_match = ( 'variable' === $type && 'variable-subscription' === $existing_type );
+				if ( $is_simple_sub_match || $is_variable_sub_match ) {
 					$product = $existing_product;
 				}
-				unset( $existing_product );
+				unset( $existing_product, $existing_type, $is_simple_sub_match, $is_variable_sub_match );
 			}
 
 			if ( null === $product ) {

--- a/readme.txt
+++ b/readme.txt
@@ -221,6 +221,9 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 
 == Changelog ==
 
+= next =
+* 
+
 = 3.3.4 =
 * Added: Log payload metabox (Connect Log Payload) is now saved and shown only when Debug Mode is active in the plugin settings.
 * Enhancement: Added `billing_cif` to the VAT field slug list so orders whose billing tax ID is stored in the `_billing_cif` meta key (e.g. from the WC-APG NIF/CIF/NIE plugin) are correctly synced to the ERP.

--- a/readme.txt
+++ b/readme.txt
@@ -222,7 +222,7 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 == Changelog ==
 
 = next =
-* 
+* Added: WooCommerce Subscriptions support — product sync from ERP no longer overwrites the product type when it already exists in the store as a subscription or variable-subscription.
 
 = 3.3.4 =
 * Added: Log payload metabox (Connect Log Payload) is now saved and shown only when Debug Mode is active in the plugin settings.

--- a/tests/WooCommerce/CreateProductVariableTest.php
+++ b/tests/WooCommerce/CreateProductVariableTest.php
@@ -649,4 +649,100 @@ class CreateProductVariableTest extends WP_UnitTestCase {
 
 		wp_delete_post( $result_prod_id, true );
 	}
+
+	/**
+	 * When the ERP serializes a numeric SKU as a JSON number, json_decode() gives
+	 * $variant['sku'] as an int, while WC_Product_Variation::get_sku() always
+	 * returns a string. The strict array_search() used to match existing
+	 * variations must not miss this case, or the sync treats an existing
+	 * variation as new (and duplicate-SKU logic can then reject it).
+	 */
+	public function test_variation_matched_when_erp_sku_is_numeric() {
+		$item_path = UNIT_TESTS_DATA_PLUGIN_DIR . 'product-variable.json';
+		$item      = file_get_contents( $item_path );
+		$item      = json_decode( $item, true )[0];
+
+		$this->settings['catattr'] = 'sandalias';
+		$this->settings['catnp']   = 'yes';
+
+		// Numeric SKUs, as an ERP that serializes them as JSON numbers would.
+		$item['variants'][0]['sku'] = 1001;
+		$item['variants'][1]['sku'] = 1002;
+
+		$result_sync    = PROD::sync_product_item( $this->settings, $item, $this->connapi_erp );
+		$result_prod_id = $result_sync['post_id'];
+		$this->assertEquals( 'ok', $result_sync['status'] );
+
+		$product    = wc_get_product( $result_prod_id );
+		$variations = $product->get_children();
+		$this->assertCount( 2, $variations, 'Expected two variations after first sync.' );
+
+		// Resync with the same (numeric) SKUs — must match the existing
+		// variations rather than creating duplicates or new ones.
+		$result_resync = PROD::sync_product_item( $this->settings, $item, $this->connapi_erp, false, $result_prod_id );
+		$this->assertEquals( 'ok', $result_resync['status'] );
+
+		$product_after    = wc_get_product( $result_prod_id );
+		$variations_after = $product_after->get_children();
+		$this->assertCount( 2, $variations_after, 'Resync with numeric SKUs must not create duplicate variations.' );
+		$this->assertEqualsCanonicalizing( $variations, $variations_after, 'Resync with numeric SKUs must match the same existing variations, not create new ones.' );
+
+		wp_delete_post( $result_prod_id, true );
+	}
+
+	/**
+	 * A new ERP variant whose SKU already belongs to a variation of a DIFFERENT
+	 * product must be rejected gracefully ("Duplicated SKU" message), not cause
+	 * WooCommerce's own duplicate-SKU exception to abort the whole sync — the
+	 * duplicate check must also search product_variation posts, not just
+	 * top-level products.
+	 */
+	public function test_duplicate_sku_against_another_products_variation_is_handled_gracefully() {
+		$item_path = UNIT_TESTS_DATA_PLUGIN_DIR . 'product-variable.json';
+		$item      = file_get_contents( $item_path );
+		$item      = json_decode( $item, true )[0];
+
+		$this->settings['catattr'] = 'sandalias';
+		$this->settings['catnp']   = 'yes';
+
+		// Create a first variable product normally.
+		$result_sync      = PROD::sync_product_item( $this->settings, $item, $this->connapi_erp );
+		$first_product_id = $result_sync['post_id'];
+		$this->assertEquals( 'ok', $result_sync['status'] );
+
+		$taken_sku = $item['variants'][0]['sku'];
+
+		// A second, already-existing variable product (created directly with its
+		// own parent SKU, bypassing the ERP-variant-SKU parent-discovery in
+		// sync_product_item(), which is not what this test is about) whose first
+		// variant reuses a SKU that already belongs to a variation of the first
+		// product.
+		$second_parent = new WC_Product_Variable();
+		$second_parent->set_name( 'Second Shoes' );
+		$second_parent->set_sku( 'second-parent-sku' );
+		$second_parent->set_status( 'publish' );
+		$second_parent->save();
+		$second_product_id = $second_parent->get_id();
+
+		$second_item                        = $item;
+		$second_item['sku']                 = 'second-parent-sku';
+		$second_item['variants'][0]['sku']  = $taken_sku;
+		$second_item['variants'][1]['sku']  = 'second-parent-variant-2';
+
+		$result_second = PROD::sync_product( $this->settings, $second_item, $this->connapi_erp, $second_product_id, 'variable', null );
+
+		// Must complete gracefully — not "error" from an uncaught WooCommerce
+		// duplicate-SKU exception.
+		$this->assertEquals( 'ok', $result_second['status'], 'Sync must not abort when a variant SKU collides with another product\'s variation.' );
+		$this->assertStringContainsString( 'Duplicated SKU', $result_second['message'], 'Result message must report the duplicated SKU.' );
+
+		$second_product    = wc_get_product( $second_product_id );
+		$second_variations = $second_product->get_children();
+
+		// Only the non-colliding variant should have been created.
+		$this->assertCount( 1, $second_variations, 'Only the variant with a unique SKU should be created.' );
+
+		wp_delete_post( $first_product_id, true );
+		wp_delete_post( $second_product_id, true );
+	}
 }

--- a/tests/WooCommerce/SubscriptionProductSyncTest.php
+++ b/tests/WooCommerce/SubscriptionProductSyncTest.php
@@ -121,8 +121,12 @@ class SubscriptionProductSyncTest extends WP_UnitTestCase {
 		$product->set_status( 'publish' );
 		$product->set_regular_price( $price );
 		$product->save();
-		wp_set_object_terms( $product->get_id(), $type, 'product_type' );
-		return $product->get_id();
+		$product_id = $product->get_id();
+		wp_set_object_terms( $product_id, $type, 'product_type' );
+		// Flush all relevant caches so subsequent wc_get_product() reads fresh data.
+		clean_post_cache( $product_id );
+		wc_delete_product_transients( $product_id );
+		return $product_id;
 	}
 
 	/**

--- a/tests/WooCommerce/SubscriptionProductSyncTest.php
+++ b/tests/WooCommerce/SubscriptionProductSyncTest.php
@@ -22,10 +22,16 @@ class Mock_WC_Product_Subscription extends WC_Product_Simple {
 
 /**
  * Minimal stub for WC_Product_Variable_Subscription.
+ *
+ * WC_Product::__construct() resolves its data store via
+ * WC_Data_Store::load( 'product-' . $this->get_type() ), so overriding
+ * get_type() alone makes it request a 'product-variable-subscription' store.
+ * That key isn't registered, so WC_Data_Store falls back to the bare
+ * 'product' store (WC_Product_Data_Store_CPT), which has no read_children().
+ * Register the key via the woocommerce_data_stores filter (setUp()) so it
+ * resolves to the same store class as 'product-variable'.
  */
 class Mock_WC_Product_Variable_Subscription extends WC_Product_Variable {
-	protected $data_store_name = 'product-variable';
-
 	public function get_type() {
 		return 'variable-subscription';
 	}
@@ -50,6 +56,11 @@ class SubscriptionProductSyncTest extends WP_UnitTestCase {
 		// Route subscription product types to the mock stubs so wc_get_product()
 		// returns the correct class without WooCommerce Subscriptions installed.
 		add_filter( 'woocommerce_product_class', array( $this, 'map_subscription_classes' ), 10, 2 );
+
+		// Mirror what WooCommerce Subscriptions itself does: register the
+		// 'product-variable-subscription' data store key so the mock's
+		// get_children()/data store calls resolve like a real variable product.
+		add_filter( 'woocommerce_data_stores', array( $this, 'map_subscription_data_stores' ) );
 
 		$this->settings = array(
 			'api'            => '',
@@ -90,7 +101,18 @@ class SubscriptionProductSyncTest extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		remove_filter( 'woocommerce_product_class', array( $this, 'map_subscription_classes' ) );
+		remove_filter( 'woocommerce_data_stores', array( $this, 'map_subscription_data_stores' ) );
 		parent::tearDown();
+	}
+
+	/**
+	 * Filter callback: reuse the 'product-variable' data store for
+	 * 'product-variable-subscription' so the mock behaves like a real
+	 * variable product (get_children(), variation reads, etc.).
+	 */
+	public function map_subscription_data_stores( $stores ) {
+		$stores['product-variable-subscription'] = $stores['product-variable'];
+		return $stores;
 	}
 
 	/**
@@ -124,6 +146,12 @@ class SubscriptionProductSyncTest extends WP_UnitTestCase {
 		$product_id = $product->get_id();
 		wp_set_object_terms( $product_id, $type, 'product_type' );
 		// Flush all relevant caches so subsequent wc_get_product() reads fresh data.
+		// WC_Product_Data_Store_CPT::get_product_type() caches the resolved type
+		// under its own 'products' cache group key, which clean_post_cache() and
+		// wc_delete_product_transients() do not touch — without this, wc_get_product()
+		// keeps returning the pre-taxonomy-change type (e.g. 'simple').
+		$type_cache_key = WC_Cache_Helper::get_cache_prefix( 'product_' . $product_id ) . '_type_' . $product_id;
+		wp_cache_delete( $type_cache_key, 'products' );
 		clean_post_cache( $product_id );
 		wc_delete_product_transients( $product_id );
 		return $product_id;
@@ -160,10 +188,11 @@ class SubscriptionProductSyncTest extends WP_UnitTestCase {
 	public function test_simple_erp_preserves_subscription_type() {
 		$product_id = $this->create_product_with_type( 'subscription', 'sub-erp-sku-1' );
 
-		PROD::sync_product( $this->settings, $this->simple_item( 'sub-erp-sku-1' ), $this->connapi_erp, $product_id, 'simple', null );
+		PROD::sync_product( $this->settings, $this->simple_item( 'sub-erp-sku-1', 77.5 ), $this->connapi_erp, $product_id, 'simple', null );
 
 		$synced = wc_get_product( $product_id );
 		$this->assertEquals( 'subscription', $synced->get_type() );
+		$this->assertEquals( '77.5', $synced->get_meta( '_subscription_price' ), '_subscription_price must be kept in sync with the ERP price.' );
 
 		wp_delete_post( $product_id, true );
 	}
@@ -230,6 +259,55 @@ class SubscriptionProductSyncTest extends WP_UnitTestCase {
 				"Variation {$child_id}: _subscription_price must match regular_price."
 			);
 		}
+
+		wp_delete_post( $product_id, true );
+	}
+
+	/**
+	 * A new variant added to an existing variable-subscription must inherit
+	 * the billing schedule from an existing sibling variation, not just the
+	 * parent product — WC Subscriptions stores the schedule per-variation,
+	 * so a parent with no such meta must not leave the new variant blank.
+	 */
+	public function test_new_variant_inherits_schedule_from_sibling_not_parent() {
+		$product_id = $this->create_product_with_type( 'variable-subscription', 'varsub-schedule-sku-1' );
+
+		$item          = json_decode( file_get_contents( UNIT_TESTS_DATA_PLUGIN_DIR . 'product-variable.json' ), true )[0];
+		$item['sku']   = 'varsub-schedule-sku-1';
+		$first_variant = $item['variants'][0];
+		$item['variants'] = array( $first_variant );
+
+		// First sync: only one variant exists yet, so it falls back to the
+		// parent's (empty) schedule meta — matches a real first-time import.
+		PROD::sync_product( $this->settings, $item, $this->connapi_erp, $product_id, 'variable', null );
+
+		$parent           = wc_get_product( $product_id );
+		$existing_children = $parent->get_children();
+		$this->assertCount( 1, $existing_children, 'Expected exactly one variation after first sync.' );
+
+		// Simulate the merchant setting a billing schedule directly on the
+		// existing variation (the parent itself still has none).
+		$existing_variation = wc_get_product( $existing_children[0] );
+		$existing_variation->update_meta_data( '_subscription_period', 'month' );
+		$existing_variation->update_meta_data( '_subscription_period_interval', '3' );
+		$existing_variation->save();
+
+		$this->assertEmpty( get_post_meta( $product_id, '_subscription_period', true ), 'Parent must have no schedule meta for this test to be meaningful.' );
+
+		// Second sync: ERP now sends both variants, so the second one is new.
+		$item_full          = json_decode( file_get_contents( UNIT_TESTS_DATA_PLUGIN_DIR . 'product-variable.json' ), true )[0];
+		$item_full['sku']   = 'varsub-schedule-sku-1';
+		PROD::sync_product( $this->settings, $item_full, $this->connapi_erp, $product_id, 'variable', null );
+
+		$parent_after   = wc_get_product( $product_id );
+		$children_after = $parent_after->get_children();
+		$this->assertCount( 2, $children_after, 'Expected a second variation after second sync.' );
+
+		$new_child_id = current( array_diff( $children_after, $existing_children ) );
+		$new_variation = wc_get_product( $new_child_id );
+
+		$this->assertEquals( 'month', $new_variation->get_meta( '_subscription_period' ), 'New variant must inherit schedule from sibling variation.' );
+		$this->assertEquals( '3', $new_variation->get_meta( '_subscription_period_interval' ), 'New variant must inherit schedule from sibling variation.' );
 
 		wp_delete_post( $product_id, true );
 	}

--- a/tests/WooCommerce/SubscriptionProductSyncTest.php
+++ b/tests/WooCommerce/SubscriptionProductSyncTest.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Class SubscriptionProductSyncTest
+ *
+ * Command: composer test -- --filter=SubscriptionProductSyncTest
+ *
+ * @package Connect_Ecommerce
+ */
+
+use CLOSE\ConnectEcommerce\Helpers\PROD;
+
+/**
+ * Minimal stub for WC_Product_Subscription (WooCommerce Subscriptions plugin).
+ * Registers the 'subscription' product type so wc_get_product() returns it
+ * without requiring the actual plugin to be active.
+ */
+class Mock_WC_Product_Subscription extends WC_Product_Simple {
+	public function get_type() {
+		return 'subscription';
+	}
+}
+
+/**
+ * Minimal stub for WC_Product_Variable_Subscription.
+ */
+class Mock_WC_Product_Variable_Subscription extends WC_Product_Variable {
+	protected $data_store_name = 'product-variable';
+
+	public function get_type() {
+		return 'variable-subscription';
+	}
+}
+
+/**
+ * Verifies that ERP product sync preserves subscription product types and
+ * correctly syncs subscription prices.
+ *
+ * @group woocommerce
+ */
+class SubscriptionProductSyncTest extends WP_UnitTestCase {
+
+	protected $settings;
+	protected $connapi_erp;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->assertTrue( class_exists( 'WooCommerce' ), 'WooCommerce is not active' );
+
+		// Route subscription product types to the mock stubs so wc_get_product()
+		// returns the correct class without WooCommerce Subscriptions installed.
+		add_filter( 'woocommerce_product_class', array( $this, 'map_subscription_classes' ), 10, 2 );
+
+		$this->settings = array(
+			'api'            => '',
+			'idcentre'       => '',
+			'url'            => '',
+			'username'       => '',
+			'password'       => '',
+			'company'        => '',
+			'domain'         => '',
+			'dbname'         => '',
+			'stock'          => 'no',
+			'prodst'         => 'draft',
+			'virtual'        => 'no',
+			'backorders'     => 'no',
+			'catsep'         => '',
+			'catattr'        => '',
+			'filter'         => '',
+			'filter_sku'     => '',
+			'tax_option'     => 'no',
+			'rates'          => 'default',
+			'catnp'          => 'yes',
+			'doctype'        => 'invoice',
+			'series'         => '',
+			'freeorder'      => 'no',
+			'ecstatus'       => 'all',
+			'order_tags'     => '',
+			'design_id'      => '',
+			'sync'           => 'no',
+			'sync_num'       => 5,
+			'sync_email'     => 'yes',
+			'prod_weight_eq' => '',
+			'debug_log'      => 'no',
+		);
+
+		$options           = conecom_get_options();
+		$this->connapi_erp = new Connect_Ecommerce_Clientify( $options );
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'woocommerce_product_class', array( $this, 'map_subscription_classes' ) );
+		parent::tearDown();
+	}
+
+	/**
+	 * Filter callback: map subscription type slugs to the mock stubs.
+	 */
+	public function map_subscription_classes( $classname, $product_type ) {
+		if ( 'subscription' === $product_type ) {
+			return 'Mock_WC_Product_Subscription';
+		}
+		if ( 'variable-subscription' === $product_type ) {
+			return 'Mock_WC_Product_Variable_Subscription';
+		}
+		return $classname;
+	}
+
+	/**
+	 * Create a product and force its product_type taxonomy term.
+	 *
+	 * @param string $type  WooCommerce product type slug.
+	 * @param string $sku   SKU for the product.
+	 * @param string $price Regular price.
+	 * @return int Product ID.
+	 */
+	private function create_product_with_type( $type, $sku, $price = '10.00' ) {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test ' . $type );
+		$product->set_sku( $sku );
+		$product->set_status( 'publish' );
+		$product->set_regular_price( $price );
+		$product->save();
+		wp_set_object_terms( $product->get_id(), $type, 'product_type' );
+		return $product->get_id();
+	}
+
+	/**
+	 * Build a minimal simple ERP item array.
+	 *
+	 * @param string $sku
+	 * @param float  $price
+	 * @return array
+	 */
+	private function simple_item( $sku, $price = 25.00 ) {
+		return array(
+			'id'         => 'erp-' . $sku,
+			'kind'       => 'simple',
+			'name'       => 'Product ' . $sku,
+			'desc'       => '',
+			'sku'        => $sku,
+			'price'      => $price,
+			'weight'     => 0,
+			'taxes'      => array(),
+			'stock'      => 0,
+			'barcode'    => '',
+			'rates'      => array(),
+			'attributes' => array(),
+		);
+	}
+
+	/**
+	 * When ERP sends a simple item and the product already exists as a
+	 * subscription, the product type must remain 'subscription' after sync.
+	 */
+	public function test_simple_erp_preserves_subscription_type() {
+		$product_id = $this->create_product_with_type( 'subscription', 'sub-erp-sku-1' );
+
+		PROD::sync_product( $this->settings, $this->simple_item( 'sub-erp-sku-1' ), $this->connapi_erp, $product_id, 'simple', null );
+
+		$synced = wc_get_product( $product_id );
+		$this->assertEquals( 'subscription', $synced->get_type() );
+
+		wp_delete_post( $product_id, true );
+	}
+
+	/**
+	 * When ERP sends a variable item and the product already exists as a
+	 * variable-subscription, the product type must remain 'variable-subscription'
+	 * after sync.
+	 */
+	public function test_variable_erp_preserves_variable_subscription_type() {
+		$product_id = $this->create_product_with_type( 'variable-subscription', 'varsub-erp-sku-1' );
+
+		$item      = json_decode( file_get_contents( UNIT_TESTS_DATA_PLUGIN_DIR . 'product-variable.json' ), true )[0];
+		$item['sku'] = 'varsub-erp-sku-1';
+
+		PROD::sync_product( $this->settings, $item, $this->connapi_erp, $product_id, 'variable', null );
+
+		$synced = wc_get_product( $product_id );
+		$this->assertEquals( 'variable-subscription', $synced->get_type() );
+
+		wp_delete_post( $product_id, true );
+	}
+
+	/**
+	 * When ERP sends a variable item but the existing product is a simple
+	 * subscription, the two shapes do not match and sync must complete without
+	 * errors (no preservation, no crash).
+	 */
+	public function test_variable_erp_with_simple_subscription_does_not_error() {
+		$product_id = $this->create_product_with_type( 'subscription', 'sub-mismatch-sku-1' );
+
+		$item        = json_decode( file_get_contents( UNIT_TESTS_DATA_PLUGIN_DIR . 'product-variable.json' ), true )[0];
+		$item['sku'] = 'sub-mismatch-sku-1';
+
+		$result = PROD::sync_product( $this->settings, $item, $this->connapi_erp, $product_id, 'variable', null );
+
+		$this->assertNotEquals( 'error', $result['status'] ?? '', 'Shape mismatch must not cause a sync error.' );
+
+		wp_delete_post( $product_id, true );
+	}
+
+	/**
+	 * When syncing variations under a variable-subscription parent, each
+	 * variation must have _subscription_price set to the same value as its
+	 * regular price from the ERP.
+	 */
+	public function test_variable_subscription_variants_get_subscription_price() {
+		$product_id = $this->create_product_with_type( 'variable-subscription', 'varsub-price-sku-1' );
+
+		$item        = json_decode( file_get_contents( UNIT_TESTS_DATA_PLUGIN_DIR . 'product-variable.json' ), true )[0];
+		$item['sku'] = 'varsub-price-sku-1';
+
+		PROD::sync_product( $this->settings, $item, $this->connapi_erp, $product_id, 'variable', null );
+
+		$parent   = wc_get_product( $product_id );
+		$children = $parent->get_children();
+		$this->assertNotEmpty( $children, 'Variable-subscription must have variations after sync.' );
+
+		foreach ( $children as $child_id ) {
+			$variation = wc_get_product( $child_id );
+			$this->assertEquals(
+				$variation->get_regular_price(),
+				$variation->get_meta( '_subscription_price' ),
+				"Variation {$child_id}: _subscription_price must match regular_price."
+			);
+		}
+
+		wp_delete_post( $product_id, true );
+	}
+}


### PR DESCRIPTION
## Summary

Prevents WooCommerce subscription products from being converted to simple/variable products when syncing from the ERP. Since the ERP has no subscription concept, existing subscription product types are now preserved during product updates.

## Changes

- **Product sync logic** (`includes/Helpers/PROD.php`): Added a check to preserve subscription product types (`subscription`, `variable-subscription`) when updating existing products. If a product is not new and already has a subscription type, the existing product object is reused instead of creating a new one based on the ERP product type.
- **Changelog**: Added placeholder entry for next release.

## Implementation Details

The fix wraps the product instantiation logic with a conditional that:
1. Checks if the product is not new (`!$is_new_product`)
2. Retrieves the existing product and checks if its type is in the subscription types list
3. Reuses the existing product object if it's a subscription type
4. Falls back to the original type-based instantiation for non-subscription products

This ensures subscription-specific metadata and product type are maintained during ERP synchronization.


<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fshop%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Fwoocommerce-es%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-192-3bff863f713621ea5eed46c7f276757ac16c37f5.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22woocommerce%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->