### PR TITLE
Add ERP tax ID to WooCommerce tax class helper

### DIFF
--- a/includes/Admin/Taxes_Types_ERP.php
+++ b/includes/Admin/Taxes_Types_ERP.php
@@ -97,12 +97,22 @@ class Taxes_Types_ERP {
 		);
 		$options_html .= '</option>';
 		if ( ! empty( $taxes ) && is_array( $taxes ) ) {
+			// Odoo can have several taxes sharing the same display name (e.g.
+			// different companies/fiscal positions). Count labels first so
+			// duplicates get their ID appended and the user can tell them apart.
+			$label_counts = array();
+			foreach ( $taxes as $tax ) {
+				$label                  = isset( $tax['name'] ) ? $tax['name'] : '';
+				$label_counts[ $label ] = ( isset( $label_counts[ $label ] ) ? $label_counts[ $label ] : 0 ) + 1;
+			}
+
 			foreach ( $taxes as $tax ) {
 				$id    = isset( $tax['id'] ) ? $tax['id'] : '';
 				$label = isset( $tax['name'] ) ? $tax['name'] : $id;
 
 				if ( $id ) {
-					$options_html .= '<option value="' . esc_attr( $id ) . '">' . esc_html( $label ) . '</option>';
+					$option_label = $label_counts[ $label ] > 1 ? $label . ' (ID: ' . $id . ')' : $label;
+					$options_html .= '<option value="' . esc_attr( $id ) . '">' . esc_html( $option_label ) . '</option>';
 				}
 			}
 		}

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -609,7 +609,6 @@ class PROD {
 				'parent_id'     => $product_id,
 				'attributes'    => $attributes_prod,
 				'regular_price' => $variation_price,
-				'tax_status'    => 'taxable',
 				'tax_class'     => 'parent',
 			);
 
@@ -620,6 +619,7 @@ class PROD {
 			if ( 0 === $variation_id ) {
 				// New variation.
 				$variation_props_new = array(
+					'tax_status'   => 'taxable',
 					'weight'       => '',
 					'length'       => '',
 					'width'        => '',

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -609,6 +609,8 @@ class PROD {
 				'parent_id'     => $product_id,
 				'attributes'    => $attributes_prod,
 				'regular_price' => $variation_price,
+				'tax_status'    => 'taxable',
+				'tax_class'     => 'parent',
 			);
 
 			$price_sale = self::get_sale_price( $variant, $settings );
@@ -618,8 +620,6 @@ class PROD {
 			if ( 0 === $variation_id ) {
 				// New variation.
 				$variation_props_new = array(
-					'tax_status'   => 'taxable',
-					'tax_class'    => 'parent',
 					'weight'       => '',
 					'length'       => '',
 					'width'        => '',

--- a/includes/Helpers/TAXES.php
+++ b/includes/Helpers/TAXES.php
@@ -94,14 +94,18 @@ class TAXES {
 
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$tax_rate_class = $wpdb->get_var(
+		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT tax_rate_class FROM {$wpdb->prefix}woocommerce_tax_rates WHERE erp_tax_type = %s LIMIT 1",
 				(string) $erp_tax_id
-			)
+			),
+			ARRAY_A
 		);
 
-		return null === $tax_rate_class ? null : $tax_rate_class;
+		// get_var() would return null both when no row matches and when the
+		// matched row's tax_rate_class is '' (standard rate) — get_row() lets
+		// us tell "no mapping" apart from "mapped to the standard class".
+		return null === $row ? null : $row['tax_rate_class'];
 	}
 
 	/**

--- a/includes/Helpers/TAXES.php
+++ b/includes/Helpers/TAXES.php
@@ -75,6 +75,36 @@ class TAXES {
 	}
 
 	/**
+	 * Get WooCommerce tax class slug mapped to a given ERP tax ID.
+	 *
+	 * Reverse lookup of get_tax_types_map(): finds the WooCommerce tax rate
+	 * whose "ERP Tax Type" column (WooCommerce > Settings > Tax) matches the
+	 * given ERP (e.g. Odoo) tax ID, and returns its tax_rate_class slug so it
+	 * can be assigned to a product's tax_class.
+	 *
+	 * @param int|string $erp_tax_id ERP tax ID (e.g. Odoo account.tax id).
+	 * @return string|null Tax class slug ('' for standard rate), or null if no mapping exists.
+	 */
+	public static function get_tax_class_by_erp_id( $erp_tax_id ) {
+		if ( '' === (string) $erp_tax_id ) {
+			return null;
+		}
+
+		self::ensure_tax_type_column();
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$tax_rate_class = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT tax_rate_class FROM {$wpdb->prefix}woocommerce_tax_rates WHERE erp_tax_type = %s LIMIT 1",
+				(string) $erp_tax_id
+			)
+		);
+
+		return null === $tax_rate_class ? null : $tax_rate_class;
+	}
+
+	/**
 	 * Ensure ERP tax type column exists in WooCommerce tax rates table.
 	 *
 	 * @return void

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Donate link: https://close.marketing/go/donate/
 Requires at least: 5.0
 Requires PHP: 7.4
 Tested up to: 7.0
-Stable tag: 3.3.4
-Version: 3.3.4
+Stable tag: 3.3.5
+Version: 3.3.5
 License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -220,6 +220,9 @@ The core connector integrates with Clientify, a CRM and marketing automation too
 This plugin uses the VIES (VAT Information Exchange System) service provided by the European Commission to validate EU VAT numbers. The VIES service is accessed through the dragonbe/vies PHP library. When a customer enters a VAT number during checkout, the plugin communicates with the VIES web service to verify the number's validity. This is an official EU service and does not store personal data. [VIES Information](https://ec.europa.eu/taxation_customs/vies/)
 
 == Changelog ==
+
+= 3.3.5 =
+* Added: New `TAXES::get_tax_class_by_erp_id()` helper method that resolves a WooCommerce tax class from an ERP/CRM tax id, using the "ERP Tax Type" mapping configured in WooCommerce > Settings > Tax. This lets connectors (e.g. Odoo) map an ERP tax id to the correct WooCommerce tax class when syncing products, reusing the same mapping already used for orders.
 
 = 3.3.4 =
 * Added: Log payload metabox (Connect Log Payload) is now saved and shown only when Debug Mode is active in the plugin settings.

--- a/tests/Unit/TaxesTypesERPTest.php
+++ b/tests/Unit/TaxesTypesERPTest.php
@@ -254,6 +254,65 @@ class TaxesTypesERPTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_tax_class_by_erp_id() returns the mapped tax class slug.
+	 */
+	public function test_get_tax_class_by_erp_id_returns_mapped_class() {
+		$tax_rate_id = \WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => 'ES',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '10.0000',
+				'tax_rate_name'     => 'IVA reducido',
+				'tax_rate_priority' => 1,
+				'tax_rate_compound' => 0,
+				'tax_rate_shipping' => 1,
+				'tax_rate_order'    => 0,
+				'tax_rate_class'    => 'reduced-rate',
+			)
+		);
+		TAXES::update_tax_type( $tax_rate_id, '291' );
+
+		$this->assertEquals( 'reduced-rate', TAXES::get_tax_class_by_erp_id( '291' ) );
+
+		\WC_Tax::_delete_tax_rate( $tax_rate_id );
+	}
+
+	/**
+	 * An ERP tax ID mapped to the WooCommerce standard class is stored with
+	 * tax_rate_class = '' — this must be distinguished from "no mapping"
+	 * (null), which is what a plain get_var() lookup would incorrectly return
+	 * for both cases.
+	 */
+	public function test_get_tax_class_by_erp_id_returns_empty_string_for_standard_rate_mapping() {
+		$tax_rate_id = \WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => 'ES',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '21.0000',
+				'tax_rate_name'     => 'IVA',
+				'tax_rate_priority' => 1,
+				'tax_rate_compound' => 0,
+				'tax_rate_shipping' => 1,
+				'tax_rate_order'    => 0,
+				'tax_rate_class'    => '',
+			)
+		);
+		TAXES::update_tax_type( $tax_rate_id, '220' );
+
+		$this->assertSame( '', TAXES::get_tax_class_by_erp_id( '220' ) );
+
+		\WC_Tax::_delete_tax_rate( $tax_rate_id );
+	}
+
+	/**
+	 * Test get_tax_class_by_erp_id() returns null when no tax rate has that
+	 * ERP tax ID mapped.
+	 */
+	public function test_get_tax_class_by_erp_id_returns_null_when_unmapped() {
+		$this->assertNull( TAXES::get_tax_class_by_erp_id( '999999' ) );
+	}
+
+	/**
 	 * Test that ERP taxes sharing the same display name get their ID appended,
 	 * so the admin can tell them apart in the dropdown (e.g. Odoo taxes 277 and
 	 * 291 both named "10% G" on different companies/fiscal positions).

--- a/tests/Unit/TaxesTypesERPTest.php
+++ b/tests/Unit/TaxesTypesERPTest.php
@@ -252,5 +252,36 @@ class TaxesTypesERPTest extends WP_UnitTestCase {
 		unset( $_POST['changes'] );
 		\WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
+
+	/**
+	 * Test that ERP taxes sharing the same display name get their ID appended,
+	 * so the admin can tell them apart in the dropdown (e.g. Odoo taxes 277 and
+	 * 291 both named "10% G" on different companies/fiscal positions).
+	 */
+	public function test_get_erp_taxes_options_disambiguates_duplicate_labels() {
+		$connector_stub = new class() {
+			public function get_taxes() {
+				return array(
+					array( 'id' => 277, 'name' => '10% G' ),
+					array( 'id' => 291, 'name' => '10% G' ),
+					array( 'id' => 220, 'name' => '21% G' ),
+				);
+			}
+		};
+
+		$connector = array(
+			'options'      => array( 'name' => 'Test ERP' ),
+			'connapi_erp'  => $connector_stub,
+		);
+
+		$taxes_erp = new Taxes_Types_ERP( $connector );
+		$method    = new ReflectionMethod( Taxes_Types_ERP::class, 'get_erp_taxes_options' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $taxes_erp );
+
+		$this->assertStringContainsString( '<option value="277">10% G (ID: 277)</option>', $result['options_html'] );
+		$this->assertStringContainsString( '<option value="291">10% G (ID: 291)</option>', $result['options_html'] );
+		$this->assertStringContainsString( '<option value="220">21% G</option>', $result['options_html'] );
+	}
 }
 

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -5,7 +5,7 @@
  * Description:       Connects Ecommerce WooCommerce to ERPs and CRMs. Syncs products, customers, orders and stock. Includes EU VAT Compliance. Import European Taxes and check VAT compliance.
  * Author:            Closetechnology
  * Author URI:        https://close.technology/
- * Version:           3.3.4
+ * Version:           3.3.5-beta.1
  * Requires PHP:      7.4
  * Requires at least: 6.3
  * Text Domain:       woocommerce-es
@@ -20,7 +20,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CONECOM_VERSION', '3.3.4' );
+define( 'CONECOM_VERSION', '3.3.5-beta.1' );
 define( 'CONECOM_FILE', __FILE__ );
 define( 'CONECOM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONECOM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -5,7 +5,7 @@
  * Description:       Connects Ecommerce WooCommerce to ERPs and CRMs. Syncs products, customers, orders and stock. Includes EU VAT Compliance. Import European Taxes and check VAT compliance.
  * Author:            Closetechnology
  * Author URI:        https://close.technology/
- * Version:           3.3.5-beta.1
+ * Version:           3.3.5-beta.2
  * Requires PHP:      7.4
  * Requires at least: 6.3
  * Text Domain:       woocommerce-es
@@ -20,7 +20,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CONECOM_VERSION', '3.3.5-beta.1' );
+define( 'CONECOM_VERSION', '3.3.5-beta.2' );
 define( 'CONECOM_FILE', __FILE__ );
 define( 'CONECOM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONECOM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
## Summary
- Adds `TAXES::get_tax_class_by_erp_id()`, a reverse lookup that maps an ERP (Odoo) tax ID to its matching WooCommerce tax class slug via the `erp_tax_type` column on `woocommerce_tax_rates`.

## Test plan
- [ ] Verify a product synced with an Odoo tax ID resolves to the correct WooCommerce tax class.
- [ ] Verify `null` is returned when no mapping exists.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fshop%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Fwoocommerce-es%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-199-aa3ef080733a358b3a574cd8d79b9ff26520bd12.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22woocommerce%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->