### PR TITLE
Add setting to control catalog visibility on out-of-stock sync

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -693,6 +693,14 @@ class Settings {
 					'connect_ecommerce_admin',
 					'connect_woocommerce_setting_section'
 				);
+
+				add_settings_field(
+					'wcpimh_stock_visibility',
+					__( 'Hide out-of-stock products?', 'woocommerce-es' ),
+					array( $this, 'stock_visibility_callback' ),
+					'connect_ecommerce_admin',
+					'connect_woocommerce_setting_section'
+				);
 			}
 
 			add_settings_field(
@@ -1518,6 +1526,7 @@ class Settings {
 				'domain'             => '',
 				'dbname'             => '',
 				'stock'              => 'no',
+				'stock_visibility'   => 'hide',
 				'prodst'             => 'draft',
 				'virtual'            => 'no',
 				'backorders'         => 'no',
@@ -1746,6 +1755,26 @@ class Settings {
 			<option value="yes" <?php selected( $stock_option, 'yes' ); ?>><?php esc_html_e( 'Yes', 'woocommerce-es' ); ?></option>
 			<option value="no" <?php selected( $stock_option, 'no' ); ?>><?php esc_html_e( 'No', 'woocommerce-es' ); ?></option>
 		</select>
+		<?php
+	}
+
+	/**
+	 * Stock visibility field
+	 *
+	 * Controls whether the sync is allowed to change a product's catalog
+	 * visibility based on stock. Defaults to "hide" to keep the historic
+	 * behaviour for existing installs.
+	 *
+	 * @return void
+	 */
+	public function stock_visibility_callback() {
+		$stock_visibility_option = isset( $this->settings['stock_visibility'] ) ? $this->settings['stock_visibility'] : 'hide';
+		?>
+		<select name="connect_ecommerce[<?php echo esc_html( $this->connector ); ?>][stock_visibility]" id="wcpimh_stock_visibility">
+			<option value="hide" <?php selected( $stock_visibility_option, 'hide' ); ?>><?php esc_html_e( 'Yes, hide out-of-stock products (default)', 'woocommerce-es' ); ?></option>
+			<option value="no_change" <?php selected( $stock_visibility_option, 'no_change' ); ?>><?php esc_html_e( 'No, do not change catalog visibility', 'woocommerce-es' ); ?></option>
+		</select>
+		<p class="description"><?php esc_html_e( 'When set to "No", the sync will still update stock status and quantity, but will not modify the catalog visibility of the product, so manual changes are preserved.', 'woocommerce-es' ); ?></p>
 		<?php
 	}
 

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -256,6 +256,7 @@ class PROD {
 	 */
 	public static function sync_product( $settings, $item, $api_erp, $product_id = 0, $type = 'simple', $pack_items = null ) {
 		$import_stock       = ! empty( $settings['stock'] ) ? $settings['stock'] : 'no';
+		$stock_visibility   = ! empty( $settings['stock_visibility'] ) ? $settings['stock_visibility'] : 'hide';
 		$is_virtual         = ! empty( $settings['virtual'] ) && 'yes' === $settings['virtual'] ? true : false;
 		$allow_backorders   = ! empty( $settings['backorders'] ) ? $settings['backorders'] : 'yes';
 		$rate_id            = ! empty( $settings['rates'] ) ? $settings['rates'] : 'default';
@@ -393,41 +394,52 @@ class PROD {
 				// Values for simple products.
 				// Check if the product can be sold.
 				if ( 'no' === $import_stock && $item['price'] > 0 ) {
-					$product_props['stock_status']       = 'instock';
-					$product_props['catalog_visibility'] = 'visible';
-					
-					try {
-						wp_remove_object_terms( $product_id, 'exclude-from-catalog', 'product_visibility' );
-						wp_remove_object_terms( $product_id, 'exclude-from-search', 'product_visibility' );
-					} catch ( \Exception $e ) {}
+					$product_props['stock_status'] = 'instock';
+
+					if ( 'hide' === $stock_visibility ) {
+						$product_props['catalog_visibility'] = 'visible';
+						try {
+							wp_remove_object_terms( $product_id, 'exclude-from-catalog', 'product_visibility' );
+							wp_remove_object_terms( $product_id, 'exclude-from-search', 'product_visibility' );
+						} catch ( \Exception $e ) {}
+					}
 				} elseif ( 'yes' === $import_stock && $item_stock > 0 ) {
-					$product_props['manage_stock']       = true;
-					$product_props['stock_quantity']     = $item_stock;
-					$product_props['stock_status']       = 'instock';
-					$product_props['catalog_visibility'] = 'visible';
-					// Only call taxonomy functions if taxonomy exists
-					try {
-						wp_remove_object_terms( $product_id, 'exclude-from-catalog', 'product_visibility' );
-						wp_remove_object_terms( $product_id, 'exclude-from-search', 'product_visibility' );
-					} catch ( \Exception $e ) {}
+					$product_props['manage_stock']   = true;
+					$product_props['stock_quantity'] = $item_stock;
+					$product_props['stock_status']   = 'instock';
+
+					if ( 'hide' === $stock_visibility ) {
+						$product_props['catalog_visibility'] = 'visible';
+						// Only call taxonomy functions if taxonomy exists
+						try {
+							wp_remove_object_terms( $product_id, 'exclude-from-catalog', 'product_visibility' );
+							wp_remove_object_terms( $product_id, 'exclude-from-search', 'product_visibility' );
+						} catch ( \Exception $e ) {}
+					}
 				} elseif ( 'yes' === $import_stock && 0 === $item_stock ) {
-					$product_props['manage_stock']       = true;
-					$product_props['catalog_visibility'] = 'hidden';
-					$product_props['stock_quantity']     = 0;
-					$product_props['stock_status']       = 'outofstock';
-					// Only call taxonomy functions if taxonomy exists
-					try {
-						wp_set_object_terms( $product_id, array( 'exclude-from-catalog', 'exclude-from-search' ), 'product_visibility' );
-					} catch ( \Exception $e ) {}
+					$product_props['manage_stock']   = true;
+					$product_props['stock_quantity'] = 0;
+					$product_props['stock_status']   = 'outofstock';
+
+					if ( 'hide' === $stock_visibility ) {
+						$product_props['catalog_visibility'] = 'hidden';
+						// Only call taxonomy functions if taxonomy exists
+						try {
+							wp_set_object_terms( $product_id, array( 'exclude-from-catalog', 'exclude-from-search' ), 'product_visibility' );
+						} catch ( \Exception $e ) {}
+					}
 				} else {
-					$product_props['manage_stock']       = true;
-					$product_props['catalog_visibility'] = 'hidden';
-					$product_props['stock_quantity']     = $item['stock'];
-					$product_props['stock_status']       = 'outofstock';
-					// Only call taxonomy functions if taxonomy exists
-					try {
-						wp_set_object_terms( $product_id, array( 'exclude-from-catalog', 'exclude-from-search' ), 'product_visibility' );
-					} catch ( \Exception $e ) {}
+					$product_props['manage_stock']   = true;
+					$product_props['stock_quantity'] = $item['stock'];
+					$product_props['stock_status']   = 'outofstock';
+
+					if ( 'hide' === $stock_visibility ) {
+						$product_props['catalog_visibility'] = 'hidden';
+						// Only call taxonomy functions if taxonomy exists
+						try {
+							wp_set_object_terms( $product_id, array( 'exclude-from-catalog', 'exclude-from-search' ), 'product_visibility' );
+						} catch ( \Exception $e ) {}
+					}
 				}
 				break;
 			case 'variable':

--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,7 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 * Added: New `TAXES::get_tax_class_by_erp_id()` helper method that resolves a WooCommerce tax class from an ERP/CRM tax id, using the "ERP Tax Type" mapping configured in WooCommerce > Settings > Tax. This lets connectors (e.g. Odoo) map an ERP tax id to the correct WooCommerce tax class when syncing products, reusing the same mapping already used for orders.
 * Fixed: Importing a variable product no longer enables "Stock management" on the parent product. Stock is tracked on the variations only; enabling it on the parent as well made the parent show as "out of stock" even when its variations had stock available. The parent's stock status is now correctly recalculated from its variations after each sync.
 * Added: WooCommerce Subscriptions support — product sync from ERP no longer overwrites the product type when it already exists in the store as a subscription or variable-subscription.
+* Added: Option to hide products out-of-stock or not change the visibility.
 
 = 3.3.4 =
 * Added: Log payload metabox (Connect Log Payload) is now saved and shown only when Debug Mode is active in the plugin settings.

--- a/tests/WooCommerce/CreateProductSimpleTest.php
+++ b/tests/WooCommerce/CreateProductSimpleTest.php
@@ -259,4 +259,75 @@ class CreateProductSimpleTest extends WP_UnitTestCase {
 
 		wp_delete_post( $result_sync_upd['post_id'], true ); // Clean up after test
 	}
+
+	/**
+	 * By default (stock_visibility = 'hide'), a product that runs out of stock
+	 * is hidden from the catalog on sync.
+	 */
+	public function test_stock_out_hides_product_by_default() {
+		$item_path = UNIT_TESTS_DATA_PLUGIN_DIR . 'product-simple.json';
+		$item      = file_get_contents( $item_path );
+		$item      = json_decode( $item, true )[0];
+
+		$this->settings['stock'] = 'yes';
+
+		$result_sync    = PROD::sync_product_item( $this->settings, $item, $this->connapi_erp );
+		$result_prod_id = $result_sync['post_id'];
+
+		$product = wc_get_product( $result_prod_id );
+		$this->assertEquals( 'visible', $product->get_catalog_visibility() );
+
+		$item['stock']   = 0;
+		$result_sync_upd = PROD::sync_product_item( $this->settings, $item, $this->connapi_erp, false, $result_prod_id );
+
+		$product = wc_get_product( $result_sync_upd['post_id'] );
+		$this->assertEquals( 'outofstock', $product->get_stock_status() );
+		$this->assertEquals( 'hidden', $product->get_catalog_visibility() );
+
+		wp_delete_post( $result_sync_upd['post_id'], true ); // Clean up after test
+	}
+
+	/**
+	 * With stock_visibility = 'no_change', running out of stock updates stock
+	 * status/quantity but must not touch catalog visibility, so manual admin
+	 * changes are preserved across syncs.
+	 */
+	public function test_stock_out_does_not_change_visibility_when_disabled() {
+		$item_path = UNIT_TESTS_DATA_PLUGIN_DIR . 'product-simple.json';
+		$item      = file_get_contents( $item_path );
+		$item      = json_decode( $item, true )[0];
+
+		$this->settings['stock']            = 'yes';
+		$this->settings['stock_visibility'] = 'no_change';
+
+		$result_sync    = PROD::sync_product_item( $this->settings, $item, $this->connapi_erp );
+		$result_prod_id = $result_sync['post_id'];
+
+		// Manually hide the product, as a shop manager could do in wp-admin.
+		wp_set_object_terms( $result_prod_id, array( 'exclude-from-catalog', 'exclude-from-search' ), 'product_visibility' );
+		$product = wc_get_product( $result_prod_id );
+		$product->set_catalog_visibility( 'hidden' );
+		$product->save();
+
+		$item['stock']   = 0;
+		$result_sync_upd = PROD::sync_product_item( $this->settings, $item, $this->connapi_erp, false, $result_prod_id );
+
+		$product = wc_get_product( $result_sync_upd['post_id'] );
+		$this->assertEquals( 'outofstock', $product->get_stock_status() );
+		$this->assertEquals( 0, $product->get_stock_quantity() );
+		// Visibility untouched by the sync (still whatever the admin set it to).
+		$this->assertEquals( 'hidden', $product->get_catalog_visibility() );
+
+		// And restoring it manually to visible must also survive a resync while out of stock.
+		$product->set_catalog_visibility( 'visible' );
+		$product->save();
+		wp_remove_object_terms( $result_prod_id, 'exclude-from-catalog', 'product_visibility' );
+		wp_remove_object_terms( $result_prod_id, 'exclude-from-search', 'product_visibility' );
+
+		$result_sync_upd = PROD::sync_product_item( $this->settings, $item, $this->connapi_erp, false, $result_prod_id );
+		$product         = wc_get_product( $result_sync_upd['post_id'] );
+		$this->assertEquals( 'visible', $product->get_catalog_visibility() );
+
+		wp_delete_post( $result_sync_upd['post_id'], true ); // Clean up after test
+	}
 }

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -5,7 +5,7 @@
  * Description:       Connects Ecommerce WooCommerce to ERPs and CRMs. Syncs products, customers, orders and stock. Includes EU VAT Compliance. Import European Taxes and check VAT compliance.
  * Author:            Closetechnology
  * Author URI:        https://close.technology/
- * Version:           3.3.5-beta.2
+ * Version:           3.3.5-beta.3
  * Requires PHP:      7.4
  * Requires at least: 6.3
  * Text Domain:       woocommerce-es
@@ -20,7 +20,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'CONECOM_VERSION', '3.3.5-beta.2' );
+define( 'CONECOM_VERSION', '3.3.5-beta.3' );
 define( 'CONECOM_FILE', __FILE__ );
 define( 'CONECOM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONECOM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
Sync used to always hide products (and force them back to visible)
based on stock, overwriting any manual catalog visibility change made
in wp-admin between syncs. Add a "Hide out-of-stock products?" option
(default: hide, matching previous behavior) so admins can opt out and
let the sync only update stock status/quantity without touching
catalog_visibility or the product_visibility terms.

Fixes #208

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fshop%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Fwoocommerce-es%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-210-d4ad7b05ff0b7a8e9210058ee0b05b65c156a54d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22woocommerce%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->