### PR TITLE
Add Brevo connector for order sync (no product catalog)

### DIFF
--- a/includes/Admin/Import_Products.php
+++ b/includes/Admin/Import_Products.php
@@ -232,6 +232,16 @@ class Import_Products {
 			return;
 		}
 
+		if ( in_array( 'product', $this->options['disable_modules'] ?? array(), true ) ) {
+			wp_send_json_success(
+				array(
+					'finish'  => true,
+					'message' => __( 'This connector does not manage a product catalog.', 'woocommerce-es' ),
+				)
+			);
+			return;
+		}
+
 		$sync_loop      = isset( $_POST['loop'] ) ? (int) $_POST['loop'] : 0;
 		$product_erp_id = isset( $_POST['product_erp_id'] ) ? sanitize_text_field( wp_unslash( $_POST['product_erp_id'] ) ) : '';
 		$product_sku    = isset( $_POST['product_sku'] ) ? sanitize_text_field( wp_unslash( $_POST['product_sku'] ) ) : '';

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -55,6 +55,14 @@ class Orders {
 	private $msg_error_orders;
 
 	/**
+	 * Fallback for the "Create document for free Orders?" setting, from the
+	 * connector's own order_import_free_order option.
+	 *
+	 * @var string
+	 */
+	private $default_freeorder;
+
+	/**
 	 * Init and hook in the integration.
 	 *
 	 * @param array $connector Connector.
@@ -68,6 +76,7 @@ class Orders {
 		$this->connapi_erp                = $connector['connapi_erp'];
 		$ecstatus                         = isset( $this->settings['ecstatus'] ) ? $this->settings['ecstatus'] : $this->options['order_only_order_completed'];
 		$this->meta_key_order             = '_' . $this->options['slug'] . '_invoice_id';
+		$this->default_freeorder          = ! empty( $this->options['order_import_free_order'] ) ? 'yes' : 'no';
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueues' ) );
 		add_action( 'wp_ajax_connect_ecommerce_sync_orders', array( $this, 'sync_orders' ) );
@@ -144,7 +153,7 @@ class Orders {
 				as_schedule_single_action( time() + 30, 'conecom_async_send_order_erp', array( $order_id ), 'connect-ecommerce' );
 			}
 		} else {
-			ORDER::create_invoice( $this->settings, $order_id, $this->meta_key_order, $this->options['slug'], $this->connapi_erp );
+			ORDER::create_invoice( $this->settings, $order_id, $this->meta_key_order, $this->options['slug'], $this->connapi_erp, false, $this->default_freeorder );
 		}
 	}
 
@@ -155,7 +164,7 @@ class Orders {
 	 * @return void
 	 */
 	public function async_send_order_erp( $order_id ) {
-		ORDER::create_invoice( $this->settings, $order_id, $this->meta_key_order, $this->options['slug'], $this->connapi_erp );
+		ORDER::create_invoice( $this->settings, $order_id, $this->meta_key_order, $this->options['slug'], $this->connapi_erp, false, $this->default_freeorder );
 	}
 
 	/**
@@ -241,7 +250,7 @@ class Orders {
 					} elseif ( ! empty( $ec_invoice_id ) && 'nocreate' !== $ec_invoice_id ) {
 						$message .= __( 'Free order not exported', 'woocommerce-es' );
 					} else {
-						$result = ORDER::create_invoice( $this->settings, $item['id'], $this->meta_key_order, $this->options['slug'], $this->connapi_erp );
+						$result = ORDER::create_invoice( $this->settings, $item['id'], $this->meta_key_order, $this->options['slug'], $this->connapi_erp, false, $this->default_freeorder );
 
 						$message .= 'ok' === $result['status'] ? __( 'Order Created.', 'woocommerce-es' ) : __( 'Order not created.', 'woocommerce-es' );
 						$message .= ' ' . $result['message'];
@@ -391,7 +400,7 @@ class Orders {
 		);
 
 		if ( 'erp-post' === $type ) {
-			$result = ORDER::create_invoice( $this->settings, $order_id, $this->meta_key_order, $this->options['slug'], $this->connapi_erp, true );
+			$result = ORDER::create_invoice( $this->settings, $order_id, $this->meta_key_order, $this->options['slug'], $this->connapi_erp, true, $this->default_freeorder );
 		}
 
 		// Check result status and respond accordingly.

--- a/includes/Admin/Orders.php
+++ b/includes/Admin/Orders.php
@@ -265,6 +265,7 @@ class Orders {
 						$args = array(
 							'message'      => $message,
 							'orders_count' => $orders_count,
+							'finish'       => $orders_synced >= $orders_count,
 						);
 						if ( $doing_ajax ) {
 							if ( $orders_synced < $orders_count ) {

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -126,6 +126,13 @@ class Settings {
 	private $is_disabled_ai;
 
 	/**
+	 * Whether the active connector does not manage a product catalog.
+	 *
+	 * @var bool
+	 */
+	private $is_disabled_products;
+
+	/**
 	 * Payment methods page handler.
 	 *
 	 * @var Settings_Payment_Methods|null
@@ -148,6 +155,7 @@ class Settings {
 		$this->is_mergevars          = $connector['is_mergevars'] ?? false;
 		$this->is_disabled_orders    = $connector['is_disabled_orders'] ?? false;
 		$this->is_disabled_ai        = $connector['is_disabled_ai'] ?? false;
+		$this->is_disabled_products  = in_array( 'product', $this->options['disable_modules'] ?? array(), true );
 		$this->have_payments_methods = ! empty( $this->connapi_erp ) && method_exists( $this->connapi_erp, 'get_payment_methods' );
 
 		// If connector is saved but the plugin is no longer active (no options/api loaded), still register the admin page so the user can change the connector.
@@ -256,7 +264,11 @@ class Settings {
 
 				// Set default subtabs.
 				if ( 'synchronization' === $active_tab && empty( $active_subtab ) ) {
-					$active_subtab = 'sync_products';
+					$active_subtab = $this->is_disabled_products ? 'sync_orders' : 'sync_products';
+				}
+				// Connectors without a product catalog only expose the Orders subtab.
+				if ( 'synchronization' === $active_tab && 'sync_products' === $active_subtab && $this->is_disabled_products ) {
+					$active_subtab = 'sync_orders';
 				}
 				if ( 'settings' === $active_tab && empty( $active_subtab ) ) {
 					$active_subtab = 'connection';
@@ -265,8 +277,9 @@ class Settings {
 				<h2 class="nav-tab-wrapper">
 					<?php
 					if ( $this->is_connector_active() ) {
+						$sync_tab_subtab = $this->is_disabled_products ? 'sync_orders' : 'sync_products';
 						?>
-						<a href="?page=connect_ecommerce&tab=synchronization&subtab=sync_products" class="nav-tab <?php echo 'synchronization' === $active_tab ? 'nav-tab-active' : ''; ?>"><?php esc_html_e( 'Synchronization', 'woocommerce-es' ); ?></a>
+						<a href="?page=connect_ecommerce&tab=synchronization&subtab=<?php echo esc_attr( $sync_tab_subtab ); ?>" class="nav-tab <?php echo 'synchronization' === $active_tab ? 'nav-tab-active' : ''; ?>"><?php esc_html_e( 'Synchronization', 'woocommerce-es' ); ?></a>
 						<?php
 					}
 					?>
@@ -301,7 +314,9 @@ class Settings {
 				if ( 'synchronization' === $active_tab && $this->is_connector_active() ) {
 					?>
 					<ul class="subsubsub">
+						<?php if ( ! $this->is_disabled_products ) : ?>
 						<li><a href="?page=connect_ecommerce&tab=synchronization&subtab=sync_products" class="<?php echo 'sync_products' === $active_subtab ? 'current' : ''; ?>"><?php esc_html_e( 'Products', 'woocommerce-es' ); ?></a><?php echo ( ! $this->is_disabled_orders ) ? ' | ' : ''; ?></li>
+						<?php endif; ?>
 						<?php
 						if ( ! $this->is_disabled_orders ) {
 							?>

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -2078,7 +2078,8 @@ class Settings {
 	 * @return void
 	 */
 	public function freeorder_callback() {
-		$freeorder = isset( $this->settings['freeorder'] ) ? $this->settings['freeorder'] : 'no';
+		$default_freeorder = ! empty( $this->options['order_import_free_order'] ) ? 'yes' : 'no';
+		$freeorder         = isset( $this->settings['freeorder'] ) ? $this->settings['freeorder'] : $default_freeorder;
 		?>
 		<select name="connect_ecommerce[<?php echo esc_html( $this->connector ); ?>][freeorder]" id="wcpimh_freeorder">
 			<option value="no" <?php selected( $freeorder, 'no' ); ?>><?php esc_html_e( 'No', 'woocommerce-es' ); ?></option>		<option value="yes" <?php selected( $freeorder, 'yes' ); ?>><?php esc_html_e( 'Yes', 'woocommerce-es' ); ?></option>

--- a/includes/Admin/Widget_Product.php
+++ b/includes/Admin/Widget_Product.php
@@ -44,6 +44,9 @@ class Widget_Product {
 		if ( empty( $connector ) || empty( $connector['connector'] ) || empty( $connector['options'] ) ) {
 			return;
 		}
+		if ( in_array( 'product', $connector['options']['disable_modules'] ?? array(), true ) ) {
+			return;
+		}
 		$this->options        = $connector['options'];
 		$this->is_disabled_ai = $connector['is_disabled_ai'] ?? false;
 		// Register Meta box for post type product.

--- a/includes/Connector/assets/brevo-logo.svg
+++ b/includes/Connector/assets/brevo-logo.svg
@@ -1,0 +1,4 @@
+<svg width="240" height="105" viewBox="0 0 240 105" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="240" height="105" fill="none"/>
+<text x="120" y="62" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="42" font-weight="700" fill="#1A73C1">Brevo</text>
+</svg>

--- a/includes/Connector/class-api-brevo.php
+++ b/includes/Connector/class-api-brevo.php
@@ -337,10 +337,12 @@ class Connect_Ecommerce_Brevo {
 			$attributes[ $attribute_name( 'sms', 'SMS' ) ] = $sms;
 		}
 
+		// $attributes always has at least firstname/lastname set above, so it is never
+		// empty here - no need to guard against PHP's empty-array-as-JSON-"[]" quirk
+		// (Brevo's API needs an object, "{}") the way an empty attributes map would.
 		$brevo_contact = array(
 			'email'         => $email,
-			// Empty PHP arrays encode to JSON "[]", but Brevo's API requires an object ("{}") here.
-			'attributes'    => ! empty( $attributes ) ? $attributes : new stdClass(),
+			'attributes'    => $attributes,
 			'updateEnabled' => true,
 		);
 

--- a/includes/Connector/class-api-brevo.php
+++ b/includes/Connector/class-api-brevo.php
@@ -193,6 +193,38 @@ class Connect_Ecommerce_Brevo {
 	}
 
 	/**
+	 * Gets the contact attribute names that exist in the Brevo account
+	 *
+	 * Brevo rejects the whole contact upsert if it includes an attribute name
+	 * that was not created in the account (accounts can rename/remove the
+	 * default FIRSTNAME/LASTNAME/SMS fields), so the account's actual
+	 * attribute list is fetched once and cached to validate against it.
+	 *
+	 * @param string $api_key API Key of Brevo.
+	 * @return array Attribute names, empty on API failure (treated as "unknown", not "none").
+	 */
+	private function get_account_attribute_names( $api_key ) {
+		$cache_key = 'conecom_brevo_contact_attributes';
+		$cached    = get_transient( $cache_key );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$names  = array();
+		$result = $this->api( 'contacts/attributes', $api_key );
+		if ( 'ok' === $result['status'] && ! empty( $result['data']['attributes'] ) ) {
+			foreach ( $result['data']['attributes'] as $attribute ) {
+				if ( ! empty( $attribute['name'] ) ) {
+					$names[] = $attribute['name'];
+				}
+			}
+			set_transient( $cache_key, $names, 12 * HOUR_IN_SECONDS );
+		}
+
+		return $names;
+	}
+
+	/**
 	 * Truncates a string without the optional mbstring extension
 	 *
 	 * Plain substr() can split a multi-byte UTF-8 character in half, which
@@ -283,20 +315,33 @@ class Connect_Ecommerce_Brevo {
 			);
 		}
 
-		// Create or update the contact in Brevo.
-		$brevo_contact = array(
-			'email'         => $email,
-			'attributes'    => array(
-				'FIRSTNAME' => $order['contactFirstName'] ?? '',
-				'LASTNAME'  => $order['contactLastName'] ?? '',
-			),
-			'updateEnabled' => true,
-		);
+		// Create or update the contact in Brevo. Only attributes that exist in the
+		// account are sent, an unknown attribute name would fail the whole upsert
+		// and the account's list could not be fetched, name fields are sent anyway
+		// since FIRSTNAME/LASTNAME are Brevo's own defaults.
+		$account_attributes = $this->get_account_attribute_names( $api_key );
+		$known_attribute    = static function ( $name ) use ( $account_attributes ) {
+			return empty( $account_attributes ) || in_array( $name, $account_attributes, true );
+		};
+
+		$attributes = array();
+		if ( $known_attribute( 'FIRSTNAME' ) ) {
+			$attributes['FIRSTNAME'] = $order['contactFirstName'] ?? '';
+		}
+		if ( $known_attribute( 'LASTNAME' ) ) {
+			$attributes['LASTNAME'] = $order['contactLastName'] ?? '';
+		}
 
 		$sms = $this->normalize_phone_e164( $order['contact_phone'] ?? '' );
-		if ( ! empty( $sms ) ) {
-			$brevo_contact['attributes']['SMS'] = $sms;
+		if ( ! empty( $sms ) && $known_attribute( 'SMS' ) ) {
+			$attributes['SMS'] = $sms;
 		}
+
+		$brevo_contact = array(
+			'email'         => $email,
+			'attributes'    => $attributes,
+			'updateEnabled' => true,
+		);
 
 		$result_contact = $this->api( 'contacts', $api_key, 'POST', $brevo_contact );
 		if ( 'error' === $result_contact['status'] ) {

--- a/includes/Connector/class-api-brevo.php
+++ b/includes/Connector/class-api-brevo.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * API Brevo.
  *
- * @since 1.0
+ * @since 3.3.5
  */
 class Connect_Ecommerce_Brevo {
 	/**
@@ -193,17 +193,19 @@ class Connect_Ecommerce_Brevo {
 	}
 
 	/**
-	 * Gets the contact attribute names that exist in the Brevo account
+	 * Gets the contact attributes map (field_key => name) that exist in the Brevo account
 	 *
 	 * Brevo rejects the whole contact upsert if it includes an attribute name
-	 * that was not created in the account (accounts can rename/remove the
-	 * default FIRSTNAME/LASTNAME/SMS fields), so the account's actual
-	 * attribute list is fetched once and cached to validate against it.
+	 * that was not created in the account, and accounts can rename the default
+	 * FIRSTNAME/LASTNAME/SMS fields to any custom name (Brevo still reports
+	 * their original purpose via "field_key": firstname/lastname/sms), so the
+	 * account's actual attribute list is fetched once and cached, keyed by
+	 * field_key, to resolve the current name for each field.
 	 *
 	 * @param string $api_key API Key of Brevo.
-	 * @return array Attribute names, empty on API failure (treated as "unknown", not "none").
+	 * @return array Map of field_key => attribute name, empty on API failure (treated as "unknown", not "none").
 	 */
-	private function get_account_attribute_names( $api_key ) {
+	private function get_account_attributes_by_field_key( $api_key ) {
 		// Keyed by API key so switching to a different Brevo account never reuses
 		// another account's cached attribute list.
 		$cache_key = 'conecom_brevo_contact_attrs_' . md5( $api_key );
@@ -212,18 +214,18 @@ class Connect_Ecommerce_Brevo {
 			return $cached;
 		}
 
-		$names  = array();
-		$result = $this->api( 'contacts/attributes', $api_key );
+		$by_field_key = array();
+		$result       = $this->api( 'contacts/attributes', $api_key );
 		if ( 'ok' === $result['status'] && ! empty( $result['data']['attributes'] ) ) {
 			foreach ( $result['data']['attributes'] as $attribute ) {
-				if ( ! empty( $attribute['name'] ) ) {
-					$names[] = $attribute['name'];
+				if ( ! empty( $attribute['name'] ) && ! empty( $attribute['field_key'] ) ) {
+					$by_field_key[ $attribute['field_key'] ] = $attribute['name'];
 				}
 			}
-			set_transient( $cache_key, $names, 12 * HOUR_IN_SECONDS );
+			set_transient( $cache_key, $by_field_key, 12 * HOUR_IN_SECONDS );
 		}
 
-		return $names;
+		return $by_field_key;
 	}
 
 	/**
@@ -317,31 +319,28 @@ class Connect_Ecommerce_Brevo {
 			);
 		}
 
-		// Create or update the contact in Brevo. Only attributes that exist in the
-		// account are sent, an unknown attribute name would fail the whole upsert
-		// and the account's list could not be fetched, name fields are sent anyway
-		// since FIRSTNAME/LASTNAME are Brevo's own defaults.
-		$account_attributes = $this->get_account_attribute_names( $api_key );
-		$known_attribute    = static function ( $name ) use ( $account_attributes ) {
-			return empty( $account_attributes ) || in_array( $name, $account_attributes, true );
+		// Create or update the contact in Brevo. Accounts can rename the default
+		// FIRSTNAME/LASTNAME/SMS fields to any custom name, so the current name for
+		// each is resolved via its field_key; if the account's list could not be
+		// fetched, the Brevo defaults are used as a fallback.
+		$account_attributes = $this->get_account_attributes_by_field_key( $api_key );
+		$attribute_name     = static function ( $field_key, $default ) use ( $account_attributes ) {
+			return $account_attributes[ $field_key ] ?? $default;
 		};
 
 		$attributes = array();
-		if ( $known_attribute( 'FIRSTNAME' ) ) {
-			$attributes['FIRSTNAME'] = $order['contactFirstName'] ?? '';
-		}
-		if ( $known_attribute( 'LASTNAME' ) ) {
-			$attributes['LASTNAME'] = $order['contactLastName'] ?? '';
-		}
+		$attributes[ $attribute_name( 'firstname', 'FIRSTNAME' ) ] = $order['contactFirstName'] ?? '';
+		$attributes[ $attribute_name( 'lastname', 'LASTNAME' ) ]   = $order['contactLastName'] ?? '';
 
 		$sms = $this->normalize_phone_e164( $order['contact_phone'] ?? '' );
-		if ( ! empty( $sms ) && $known_attribute( 'SMS' ) ) {
-			$attributes['SMS'] = $sms;
+		if ( ! empty( $sms ) ) {
+			$attributes[ $attribute_name( 'sms', 'SMS' ) ] = $sms;
 		}
 
 		$brevo_contact = array(
 			'email'         => $email,
-			'attributes'    => $attributes,
+			// Empty PHP arrays encode to JSON "[]", but Brevo's API requires an object ("{}") here.
+			'attributes'    => ! empty( $attributes ) ? $attributes : new stdClass(),
 			'updateEnabled' => true,
 		);
 

--- a/includes/Connector/class-api-brevo.php
+++ b/includes/Connector/class-api-brevo.php
@@ -174,6 +174,54 @@ class Connect_Ecommerce_Brevo {
 	}
 
 	/**
+	 * Normalizes a phone number for Brevo's SMS attribute
+	 *
+	 * Brevo validates the SMS attribute as an international number in E.164
+	 * format, while WooCommerce commonly stores local formats. Numbers that
+	 * are not already E.164 are omitted instead of sent, so they cannot make
+	 * the whole contact upsert fail.
+	 *
+	 * @param string $phone Phone number as stored in the order.
+	 * @return string
+	 */
+	private function normalize_phone_e164( $phone ) {
+		$phone = trim( (string) $phone );
+		if ( '' === $phone ) {
+			return '';
+		}
+		return preg_match( '/^\+[1-9]\d{6,14}$/', $phone ) ? $phone : '';
+	}
+
+	/**
+	 * Builds the products list for the Brevo order event
+	 *
+	 * Brevo limits the size of event properties, so long product names/SKUs
+	 * are truncated and, if the encoded payload is still too large, the
+	 * tail of the list is dropped rather than letting the whole request fail.
+	 *
+	 * @param array $items Order items.
+	 * @return array
+	 */
+	private function build_event_products( $items ) {
+		$products = array();
+		foreach ( (array) $items as $item ) {
+			$products[] = array(
+				'name'     => mb_substr( (string) ( $item['name'] ?? '' ), 0, 200 ),
+				'sku'      => mb_substr( (string) ( $item['sku'] ?? '' ), 0, 100 ),
+				'quantity' => $item['units'] ?? 0,
+				'price'    => $item['subtotal'] ?? 0,
+			);
+		}
+
+		$max_bytes = 8000;
+		while ( count( $products ) > 1 && strlen( wp_json_encode( $products ) ) > $max_bytes ) {
+			array_pop( $products );
+		}
+
+		return $products;
+	}
+
+	/**
 	 * Creates the order to Brevo
 	 *
 	 * @param array  $order Order prepared to API.
@@ -201,19 +249,36 @@ class Connect_Ecommerce_Brevo {
 			);
 		}
 
+		// Only report the order to Brevo once it is really final. With "All status orders"
+		// this method also runs on pending/processing/failed/refunded/cancelled transitions,
+		// and the first call always gets its returned id persisted as "synced" - reporting
+		// order_completed there would mark the order as done before it truly is and the
+		// real completion would never be sent.
+		$ecstatus = ! empty( $this->settings['ecstatus'] ) ? $this->settings['ecstatus'] : ( $this->options['order_only_order_completed'] ?? 'completed' );
+		$is_final = 'completed' === ( $order['woocommerceOrderStatus'] ?? '' ) || ( 'paid' === $ecstatus && ! empty( $order['is_paid'] ) );
+
+		if ( ! $is_final ) {
+			return array(
+				'status'      => 'ok',
+				'message'     => __( 'Order not completed yet, Brevo sync postponed until completion.', 'woocommerce-es' ),
+				'document_id' => '',
+				'invoice_id'  => '',
+			);
+		}
+
 		// Create or update the contact in Brevo.
 		$brevo_contact = array(
 			'email'         => $email,
 			'attributes'    => array(
 				'FIRSTNAME' => $order['contactFirstName'] ?? '',
 				'LASTNAME'  => $order['contactLastName'] ?? '',
-				'SMS'       => $order['contact_phone'] ?? '',
 			),
 			'updateEnabled' => true,
 		);
 
-		if ( ! empty( $this->settings['order_tags'] ) ) {
-			$brevo_contact['attributes']['TAGS'] = $this->settings['order_tags'];
+		$sms = $this->normalize_phone_e164( $order['contact_phone'] ?? '' );
+		if ( ! empty( $sms ) ) {
+			$brevo_contact['attributes']['SMS'] = $sms;
 		}
 
 		$result_contact = $this->api( 'contacts', $api_key, 'POST', $brevo_contact );
@@ -225,30 +290,29 @@ class Connect_Ecommerce_Brevo {
 			);
 		}
 
-		// Products are only sent as order event data, Brevo has no product catalog to keep in sync.
-		$products = array();
-		foreach ( $order['items'] as $item ) {
-			$products[] = array(
-				'name'     => $item['name'] ?? '',
-				'sku'      => $item['sku'] ?? '',
-				'quantity' => $item['units'] ?? 0,
-				'price'    => $item['subtotal'] ?? 0,
-			);
+		$order_id         = $order['woocommerceReference'] ?? $order['woocommerceOrderId'];
+		$event_properties = array(
+			'order_id'  => $order_id,
+			'total'     => $order['total'] ?? 0,
+			'currency'  => $order['currency'] ?? 'EUR',
+			'order_url' => $order['woocommerceOrderEdit'] ?? '',
+			// Products are only sent as order event data, Brevo has no product catalog to keep in sync.
+			'products'  => $this->build_event_products( $order['items'] ),
+		);
+
+		if ( ! empty( $this->settings['order_tags'] ) ) {
+			// Tags are sent as event data, not as a contact attribute: custom Brevo contact
+			// attributes must already exist in the account, and "TAGS" is not a default one.
+			$event_properties['tags'] = array_map( 'trim', explode( ',', $this->settings['order_tags'] ) );
 		}
 
-		$order_id    = $order['woocommerceReference'] ?? $order['woocommerceOrderId'];
 		$order_event = array(
-			'event_name'        => 'order_completed',
-			'identifiers'       => array(
+			'event_name'       => 'order_completed',
+			'identifiers'      => array(
 				'email_id' => $email,
 			),
-			'event_properties'  => array(
-				'order_id'  => $order_id,
-				'total'     => $order['total'] ?? 0,
-				'currency'  => $order['currency'] ?? 'EUR',
-				'order_url' => $order['woocommerceOrderEdit'] ?? '',
-				'products'  => $products,
-			),
+			'event_date'       => ! empty( $order['date'] ) ? gmdate( 'c', (int) $order['date'] ) : gmdate( 'c' ),
+			'event_properties' => $event_properties,
 		);
 
 		$result_event = $this->api( 'events', $api_key, 'POST', $order_event );

--- a/includes/Connector/class-api-brevo.php
+++ b/includes/Connector/class-api-brevo.php
@@ -193,6 +193,23 @@ class Connect_Ecommerce_Brevo {
 	}
 
 	/**
+	 * Truncates a string without the optional mbstring extension
+	 *
+	 * Plain substr() can split a multi-byte UTF-8 character in half, which
+	 * would later make wp_json_encode() fail on the whole payload, so the
+	 * string is left untouched when mbstring is not available; the byte-size
+	 * cap in build_event_products() still guards the overall payload.
+	 *
+	 * @param string $string String to truncate.
+	 * @param int    $length Max length in characters.
+	 * @return string
+	 */
+	private function truncate_string( $string, $length ) {
+		$string = (string) $string;
+		return function_exists( 'mb_substr' ) ? mb_substr( $string, 0, $length ) : $string;
+	}
+
+	/**
 	 * Builds the products list for the Brevo order event
 	 *
 	 * Brevo limits the size of event properties, so long product names/SKUs
@@ -206,8 +223,8 @@ class Connect_Ecommerce_Brevo {
 		$products = array();
 		foreach ( (array) $items as $item ) {
 			$products[] = array(
-				'name'     => mb_substr( (string) ( $item['name'] ?? '' ), 0, 200 ),
-				'sku'      => mb_substr( (string) ( $item['sku'] ?? '' ), 0, 100 ),
+				'name'     => $this->truncate_string( $item['name'] ?? '', 200 ),
+				'sku'      => $this->truncate_string( $item['sku'] ?? '', 100 ),
 				'quantity' => $item['units'] ?? 0,
 				'price'    => $item['subtotal'] ?? 0,
 			);

--- a/includes/Connector/class-api-brevo.php
+++ b/includes/Connector/class-api-brevo.php
@@ -204,7 +204,9 @@ class Connect_Ecommerce_Brevo {
 	 * @return array Attribute names, empty on API failure (treated as "unknown", not "none").
 	 */
 	private function get_account_attribute_names( $api_key ) {
-		$cache_key = 'conecom_brevo_contact_attributes';
+		// Keyed by API key so switching to a different Brevo account never reuses
+		// another account's cached attribute list.
+		$cache_key = 'conecom_brevo_contact_attrs_' . md5( $api_key );
 		$cached    = get_transient( $cache_key );
 		if ( is_array( $cached ) ) {
 			return $cached;

--- a/includes/Connector/class-api-brevo.php
+++ b/includes/Connector/class-api-brevo.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Class Brevo Connector
+ *
+ * @package    WordPress
+ * @author     David Perez <david@closemarketing.es>
+ * @copyright  2026 Closemarketing
+ * @version    1.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LoadsAPI.
+ *
+ * API Brevo.
+ *
+ * @since 1.0
+ */
+class Connect_Ecommerce_Brevo {
+	/**
+	 * Options of plugin.
+	 *
+	 * @var array
+	 */
+	private $settings;
+
+	/**
+	 * Options of plugin.
+	 *
+	 * @var array
+	 */
+	private $options;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $options Options of plugin.
+	 */
+	public function __construct( $options ) {
+		$this->options  = $options['brevo'];
+		$this->settings = get_option( 'connect_ecommerce' )['brevo'] ?? array();
+	}
+
+	/**
+	 * Checks if can sync
+	 *
+	 * @return boolean
+	 */
+	public function check_can_sync() {
+		if ( ! isset( $this->settings['api'] ) ) {
+			return false;
+		}
+		$result_login = $this->api( 'account', $this->settings['api'] );
+		if ( 'error' === $result_login['status'] ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Compatibility for Library
+	 *
+	 * @return string
+	 */
+	public function get_attributes() {
+		return '';
+	}
+
+	/**
+	 * Compatibility for Library
+	 *
+	 * @return string
+	 */
+	public function get_image_product() {
+		return '';
+	}
+
+	/**
+	 * URL for orders.
+	 *
+	 * @return string
+	 */
+	public function get_url_link_api() {
+		return '';
+	}
+
+	/**
+	 * Gets taxes from Brevo/API
+	 *
+	 * @return array Array of taxes with id, name, and code.
+	 */
+	public function get_taxes() {
+		// Brevo has no taxes endpoint, it is only used for email marketing.
+		return array();
+	}
+
+	/**
+	 * Gets information from Brevo products
+	 *
+	 * @param string $id Id of product to get information.
+	 * @param string $period Date to get YYYYMMDD.
+	 * @return array Array of products imported via API.
+	 */
+	public function get_products( $id = null, $period = null ) {
+		// Brevo has no product catalog, only orders are synced.
+		return array();
+	}
+
+	/**
+	 * Gets stock from Brevo products
+	 *
+	 * @param string $period Date YYYYMMDD for syncs.
+	 * @return array Array of products imported via API.
+	 */
+	public function get_products_stock( $period = null ) {
+		return false;
+	}
+
+	/**
+	 * Gets information from Brevo
+	 *
+	 * @param string $endpoint Endpoint of API.
+	 * @param string $apikey API Key of Brevo.
+	 * @param string $method Method of API.
+	 * @param array  $body Body of API.
+	 *
+	 * @return array
+	 */
+	private function api( $endpoint, $apikey, $method = 'GET', $body = array() ) {
+		if ( ! $apikey ) {
+			return array(
+				'status' => 'error',
+				'data'   => 'No API Key',
+			);
+		}
+		$args = array(
+			'method'  => $method,
+			'headers' => array(
+				'Content-Type' => 'application/json',
+				'Accept'       => 'application/json',
+				'api-key'      => $apikey,
+			),
+			'timeout' => 60,
+		);
+		if ( ! empty( $body ) ) {
+			$args['body'] = wp_json_encode( $body );
+		}
+		$url        = 'https://api.brevo.com/v3/' . $endpoint;
+		$result_api = wp_remote_request( $url, $args );
+
+		if ( is_wp_error( $result_api ) ) {
+			return array(
+				'status' => 'error',
+				'data'   => $result_api->get_error_message(),
+			);
+		}
+		$code      = (int) wp_remote_retrieve_response_code( $result_api );
+		$data      = json_decode( wp_remote_retrieve_body( $result_api ), true );
+		$round_100 = (int) round( $code / 100, 0 );
+
+		if ( 2 === $round_100 ) {
+			return array(
+				'status' => 'ok',
+				'data'   => $data,
+			);
+		}
+
+		$message = is_array( $data ) && isset( $data['message'] ) ? $data['message'] : wp_remote_retrieve_body( $result_api );
+		return array(
+			'status' => 'error',
+			'data'   => $message,
+		);
+	}
+
+	/**
+	 * Creates the order to Brevo
+	 *
+	 * @param array  $order Order prepared to API.
+	 * @param string $doc_id Document ID.
+	 * @param string $invoice_id Invoice ID.
+	 * @param string $force Force to create the order.
+	 *
+	 * @return array
+	 */
+	public function create_order( $order, $doc_id, $invoice_id, $force ) {
+		$api_key = ! empty( $this->settings['api'] ) ? $this->settings['api'] : '';
+
+		if ( empty( $order ) ) {
+			return array(
+				'status'  => 'error',
+				'message' => __( 'Error order not found in WooCommerce.', 'woocommerce-es' ),
+			);
+		}
+
+		$email = $order['contactEmail'] ?? '';
+		if ( empty( $email ) ) {
+			return array(
+				'status'  => 'error',
+				'message' => __( 'Error email not found in the order.', 'woocommerce-es' ),
+			);
+		}
+
+		// Create or update the contact in Brevo.
+		$brevo_contact = array(
+			'email'         => $email,
+			'attributes'    => array(
+				'FIRSTNAME' => $order['contactFirstName'] ?? '',
+				'LASTNAME'  => $order['contactLastName'] ?? '',
+				'SMS'       => $order['contact_phone'] ?? '',
+			),
+			'updateEnabled' => true,
+		);
+
+		if ( ! empty( $this->settings['order_tags'] ) ) {
+			$brevo_contact['attributes']['TAGS'] = $this->settings['order_tags'];
+		}
+
+		$result_contact = $this->api( 'contacts', $api_key, 'POST', $brevo_contact );
+		if ( 'error' === $result_contact['status'] ) {
+			$message_data = is_array( $result_contact['data'] ) ? wp_json_encode( $result_contact['data'] ) : $result_contact['data'];
+			return array(
+				'status'  => 'error',
+				'message' => __( 'Error creating the contact in Brevo. Error: ', 'woocommerce-es' ) . $message_data,
+			);
+		}
+
+		// Products are only sent as order event data, Brevo has no product catalog to keep in sync.
+		$products = array();
+		foreach ( $order['items'] as $item ) {
+			$products[] = array(
+				'name'     => $item['name'] ?? '',
+				'sku'      => $item['sku'] ?? '',
+				'quantity' => $item['units'] ?? 0,
+				'price'    => $item['subtotal'] ?? 0,
+			);
+		}
+
+		$order_id    = $order['woocommerceReference'] ?? $order['woocommerceOrderId'];
+		$order_event = array(
+			'event_name'        => 'order_completed',
+			'identifiers'       => array(
+				'email_id' => $email,
+			),
+			'event_properties'  => array(
+				'order_id'  => $order_id,
+				'total'     => $order['total'] ?? 0,
+				'currency'  => $order['currency'] ?? 'EUR',
+				'order_url' => $order['woocommerceOrderEdit'] ?? '',
+				'products'  => $products,
+			),
+		);
+
+		$result_event = $this->api( 'events', $api_key, 'POST', $order_event );
+		if ( 'error' === $result_event['status'] ) {
+			$message_data = is_array( $result_event['data'] ) ? wp_json_encode( $result_event['data'] ) : $result_event['data'];
+			return array(
+				'status'      => 'error',
+				'message'     => __( 'Order error syncing with Brevo. Error: ', 'woocommerce-es' ) . $message_data,
+				'document_id' => '',
+				'invoice_id'  => '',
+			);
+		}
+
+		return array(
+			'status'      => 'ok',
+			'message'     => __( 'The order was sent correctly to Brevo', 'woocommerce-es' ) . ' ' . $order_id,
+			'document_id' => $order_id,
+			'invoice_id'  => $order_id,
+		);
+	}
+}

--- a/includes/Helpers/ORDER.php
+++ b/includes/Helpers/ORDER.php
@@ -27,14 +27,18 @@ class ORDER {
 	 * @param string $option_prefix Option prefix.
 	 * @param object $api_erp API ERP.
 	 * @param bool   $force    Force create.
+	 * @param string $default_freeorder Fallback for the "Create document for free Orders?"
+	 *                                  setting when the merchant never saved it, lets a
+	 *                                  connector (e.g. one with no document to skip) opt in
+	 *                                  to processing free orders by default.
 	 *
 	 * @return array
 	 */
-	public static function create_invoice( $settings, $order_id, $meta_key_order, $option_prefix, $api_erp, $force = false ) {
+	public static function create_invoice( $settings, $order_id, $meta_key_order, $option_prefix, $api_erp, $force = false, $default_freeorder = 'no' ) {
 		$order          = wc_get_order( $order_id );
 		$order_total    = (float) $order->get_total();
 		$ec_invoice_id  = $order->get_meta( $meta_key_order );
-		$freeorder      = isset( $settings['freeorder'] ) ? $settings['freeorder'] : 'no';
+		$freeorder      = isset( $settings['freeorder'] ) ? $settings['freeorder'] : $default_freeorder;
 		$order_free_msg = __( 'Free order not created ', 'woocommerce-es' );
 		$is_debug_log   = isset( $settings['debug_log'] ) && 'on' === $settings['debug_log'] ? true : false;
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,8 +22,9 @@ Whether you're managing a small online store or a large e-commerce operation, th
 
 **Available Connectors**
 
-Free connector included:
+Free connectors included:
 - [Clientify](https://close.marketing/likes/clientify/)
+- [Brevo](https://www.brevo.com/)
 
 Premium connectors:
 - [Holded](https://close.technology/en/wordpress-plugins/connect-woocommerce-holded/)
@@ -213,7 +214,9 @@ Supported Services:
 - OpenAI: [Terms of use](https://openai.com/policies/row-terms-of-use/) and [Privact policy](https://openai.com/policies/row-privacy-policy/)
 - DeepSeek: [Terms of use](https://cdn.deepseek.com/policies/en-US/deepseek-terms-of-use.html) and [Privacy policy](https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html)
 
-The core connector integrates with Clientify, a CRM and marketing automation tool. [Terms of use](https://clientify.com/aviso-legal/) and [privacy policy](https://clientify.com/politicas-de-privacidad). 
+The core connector integrates with Clientify, a CRM and marketing automation tool. [Terms of use](https://clientify.com/aviso-legal/) and [privacy policy](https://clientify.com/politicas-de-privacidad).
+
+The core connector also integrates with Brevo, an email marketing and marketing automation tool. When an order is placed, the customer contact and order data are sent to Brevo. [Terms of use](https://www.brevo.com/legal/termsofuse/) and [privacy policy](https://www.brevo.com/legal/privacypolicy/).
 
 **VAT Number Validation Service**
 
@@ -222,6 +225,7 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 == Changelog ==
 
 = next =
+* Added: New Brevo connector for order sync with the Brevo email marketing platform. Brevo has no product catalog, so only customer contacts and order data are synced (products, stock, and tax import are not applicable).
 * Fixed: Reverted the "Get prices with Tax?" setting key from `tax_price` back to `tax_option`. Connector addons still read/write `tax_option`, so the 3.3.4 rename caused the setting to appear to reset to "No" after saving.
 * Enhancement: Added a "Default" option to "Get prices with Tax?" that follows WooCommerce's own "Prices entered with tax" setting (WooCommerce &gt; Settings &gt; Tax), so both settings stay in sync instead of having to be configured twice. It is now the default value for new/unset installs. Explicitly choosing "Yes" or "No" still overrides the WooCommerce setting as before. The resolved `yes`/`no` value (not the literal "default") is what gets saved and kept in sync, so connector add-ons reading `tax_option` directly always get a value they understand.
 * Added: New `TAXES::get_tax_class_by_erp_id()` helper method that resolves a WooCommerce tax class from an ERP/CRM tax id, using the "ERP Tax Type" mapping configured in WooCommerce > Settings > Tax. This lets connectors (e.g. Odoo) map an ERP tax id to the correct WooCommerce tax class when syncing products, reusing the same mapping already used for orders.

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -80,6 +80,33 @@ function conecom_get_options() {
 				'table_sync'                 => $wpdb->prefix . 'sync_conecom-clientify',
 				'file'                       => __FILE__,
 			),
+			'brevo'     => array(
+				'name'                       => 'Brevo',
+				'slug'                       => 'conecom-brevo',
+				'version'                    => CONECOM_VERSION,
+				'plugin_name'                => 'Connect WooCommerce Brevo',
+				'plugin_slug'                => 'connect-ecommerce-brevo',
+				'disable_modules'            => array( 'subscription' ),
+				'api_pagination'             => 100,
+				'product_price_tax_option'   => false,
+				'product_price_rate_option'  => false,
+				'product_option_stock'       => false,
+				'order_send_attachments'     => false,
+				'order_sync_partial'         => true,
+				'order_import_free_order'    => true,
+				'order_only_order_completed' => 'completed',
+				'order_tags'                 => true,
+				'settings_logo'              => CONECOM_PLUGIN_URL . 'includes/Connector/assets/brevo-logo.svg',
+				'settings_admin_message'     => sprintf(
+					// translators: %s url of Brevo API keys page.
+					__( 'Put your Brevo API key in order to connect and sync orders. You can find it here <a href = "%s" target = "_blank">Brevo API Keys</a>.', 'woocommerce-es' ),
+					'https://app.brevo.com/settings/keys/api'
+				),
+				'settings_special_tabs'      => array(),
+				'settings_fields'            => array( 'apipassword' ),
+				'table_sync'                 => $wpdb->prefix . 'sync_conecom-brevo',
+				'file'                       => __FILE__,
+			),
 		)
 	);
 }
@@ -93,6 +120,7 @@ add_action( 'init', 'conecom_loads' );
 function conecom_loads() {
 	require_once CONECOM_PLUGIN_PATH . 'includes/Plugin_Main.php';
 	require_once CONECOM_PLUGIN_PATH . 'includes/Connector/class-api-clientify.php';
+	require_once CONECOM_PLUGIN_PATH . 'includes/Connector/class-api-brevo.php';
 
 	$conecom_options = conecom_get_options();
 	new CLOSE\ConnectEcommerce\Base( $conecom_options );

--- a/woocommerce-es.php
+++ b/woocommerce-es.php
@@ -86,7 +86,7 @@ function conecom_get_options() {
 				'version'                    => CONECOM_VERSION,
 				'plugin_name'                => 'Connect WooCommerce Brevo',
 				'plugin_slug'                => 'connect-ecommerce-brevo',
-				'disable_modules'            => array( 'subscription' ),
+				'disable_modules'            => array( 'subscription', 'product' ),
 				'api_pagination'             => 100,
 				'product_price_tax_option'   => false,
 				'product_price_rate_option'  => false,


### PR DESCRIPTION
Brevo is an email marketing platform with no product management, so
this connector mirrors the Clientify one but only syncs orders: it
upserts the customer as a Brevo contact and sends an order_completed
event with the order data so it is available for marketing automation
and segmentation. Product/stock/tax sync are no-ops, same as the
existing admin UI already handles for connectors without a catalog.

Closes #209.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fshop%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Fwoocommerce-es%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-211-0b2e0d13c766e9f2d00bee92af096c4448d3e65c.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22woocommerce%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->