### PR TITLE
Add regression test for blank-SKU variation when ERP renames a variant's SKU

### DIFF
--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -711,26 +711,6 @@ class PROD {
 				$variation_props     = array_merge( $variation_props, $variation_props_new );
 			}
 			$variation = new \WC_Product_Variation( $variation_id );
-			if ( ! empty( $variant['barcode'] ) ) {
-				// Free the barcode from whatever product/variation currently holds it before
-				// assigning it here — WooCommerce validates global_unique_id uniqueness store-wide,
-				// so a variant that kept its barcode but got a new SKU/ID on resync (e.g. the ERP
-				// renamed it) would otherwise collide with the still-published old variation and
-				// silently fail to carry its barcode over (see catch below).
-				$barcode_holder_id = wc_get_product_id_by_global_unique_id( $variant['barcode'] );
-				if ( $barcode_holder_id && (int) $barcode_holder_id !== (int) $variation_id ) {
-					$barcode_holder = wc_get_product( $barcode_holder_id );
-					if ( $barcode_holder ) {
-						$barcode_holder->set_global_unique_id( '' );
-						$barcode_holder->save();
-					}
-				}
-				try {
-					$variation->set_global_unique_id( $variant['barcode'] );
-				} catch ( \Exception $e ) {
-					// Error.
-				}
-			}
 			$variation->set_props( $variation_props );
 
 			// For variable-subscription products, sync subscription price and schedule.
@@ -801,6 +781,32 @@ class PROD {
 				// Covers brand-new products and new variants added to an existing
 				// product — both cases need the SKU set once, on creation.
 				$variation->set_sku( $variant['sku'] );
+			}
+
+			if ( ! empty( $variant['barcode'] ) ) {
+				// WooCommerce validates global_unique_id uniqueness store-wide, so if the ERP
+				// renamed this variant's SKU on resync (new $variation_id, unmatched by SKU),
+				// its own barcode is still held by the now-orphaned sibling variation of this
+				// same parent — free it there first, but only when it's confirmed to be that
+				// stale sibling (same parent, same ERP variant id when available), never an
+				// unrelated product that merely happens to share the barcode.
+				$barcode_holder_id = wc_get_product_id_by_global_unique_id( $variant['barcode'] );
+				if ( $barcode_holder_id && (int) $barcode_holder_id !== (int) $variation_id ) {
+					$barcode_holder   = wc_get_product( $barcode_holder_id );
+					$is_stale_sibling = $barcode_holder
+						&& $barcode_holder->is_type( 'variation' )
+						&& (int) $barcode_holder->get_parent_id() === (int) $product_id
+						&& (string) $barcode_holder->get_meta( '_connect_ecommerce_productid' ) === (string) $variant['id'];
+					if ( $is_stale_sibling ) {
+						$barcode_holder->set_global_unique_id( '' );
+						$barcode_holder->save();
+					}
+				}
+				try {
+					$variation->set_global_unique_id( $variant['barcode'] );
+				} catch ( \Exception $e ) {
+					// Error.
+				}
 			}
 
 			// Custom fields for variations.

--- a/includes/Helpers/PROD.php
+++ b/includes/Helpers/PROD.php
@@ -712,6 +712,19 @@ class PROD {
 			}
 			$variation = new \WC_Product_Variation( $variation_id );
 			if ( ! empty( $variant['barcode'] ) ) {
+				// Free the barcode from whatever product/variation currently holds it before
+				// assigning it here — WooCommerce validates global_unique_id uniqueness store-wide,
+				// so a variant that kept its barcode but got a new SKU/ID on resync (e.g. the ERP
+				// renamed it) would otherwise collide with the still-published old variation and
+				// silently fail to carry its barcode over (see catch below).
+				$barcode_holder_id = wc_get_product_id_by_global_unique_id( $variant['barcode'] );
+				if ( $barcode_holder_id && (int) $barcode_holder_id !== (int) $variation_id ) {
+					$barcode_holder = wc_get_product( $barcode_holder_id );
+					if ( $barcode_holder ) {
+						$barcode_holder->set_global_unique_id( '' );
+						$barcode_holder->save();
+					}
+				}
 				try {
 					$variation->set_global_unique_id( $variant['barcode'] );
 				} catch ( \Exception $e ) {

--- a/tests/Data/product-variable-new-variant-resync.json
+++ b/tests/Data/product-variable-new-variant-resync.json
@@ -1,0 +1,81 @@
+[
+	{
+		"id": "999-generic-bra",
+		"kind": "variants",
+		"name": "Generic Bra",
+		"desc": "",
+		"typeId": "",
+		"contactId": "",
+		"contactName": "",
+		"price": 39.9,
+		"taxes": [
+			"s_iva_21"
+		],
+		"total": 48.28,
+		"hasStock": true,
+		"stock": 0,
+		"barcode": "",
+		"sku": "GENBRA",
+		"cost": 20,
+		"purchasePrice": "",
+		"weight": 0.2,
+		"tags": [],
+		"categoryId": "cat-bras",
+		"factoryCode": "",
+		"forSale": 1,
+		"forPurchase": 1,
+		"salesChannelId": null,
+		"expAccountId": null,
+		"warehouseId": "wh-1",
+		"rates": [
+			{
+				"id": "rate-1",
+				"subtotal": 32.97,
+				"taxes": [
+					"s_iva_21"
+				]
+			}
+		],
+		"attributes": [
+			{
+				"id": "attr-cat",
+				"name": "categoria",
+				"value": "Bras"
+			}
+		],
+		"variants": [
+			{
+				"id": "9001",
+				"barcode": "0000000000001",
+				"sku": "GENBRA-85D-CH",
+				"price": 39.9,
+				"cost": 20,
+				"purchasePrice": 0,
+				"stock": 0,
+				"categoryFields": [
+					{ "id": "field-color", "name": "color", "field": "beige" },
+					{ "id": "field-talla", "name": "talla", "field": "75AA" }
+				],
+				"rates": {
+					"rate-1": { "id": "rate-1", "subtotal": 32.97, "taxes": [ "s_iva_21" ] }
+				}
+			},
+			{
+				"id": "9002",
+				"barcode": "0000000000002",
+				"sku": "GENBRA-85D-MC",
+				"price": 39.9,
+				"cost": 20,
+				"purchasePrice": 0,
+				"stock": 0,
+				"categoryFields": [
+					{ "id": "field-color", "name": "color", "field": "mocha" },
+					{ "id": "field-talla", "name": "talla", "field": "75AA" }
+				],
+				"rates": {
+					"rate-1": { "id": "rate-1", "subtotal": 32.97, "taxes": [ "s_iva_21" ] }
+				}
+			}
+		]
+	}
+]

--- a/tests/WooCommerce/CreateProductVariableTest.php
+++ b/tests/WooCommerce/CreateProductVariableTest.php
@@ -745,4 +745,91 @@ class CreateProductVariableTest extends WP_UnitTestCase {
 		wp_delete_post( $first_product_id, true );
 		wp_delete_post( $second_product_id, true );
 	}
+
+	/**
+	 * Regression test: blank SKU when the ERP renames an existing variant's SKU on resync.
+	 *
+	 * Reproduces a production issue reported for an Odoo-synced variable product:
+	 * a variant was originally synced with one SKU, then the ERP corrected that
+	 * SKU on a later sync (same ERP variant id, same attributes, no change to
+	 * the underlying variant identity).
+	 *
+	 * woocommerce-es matches an incoming variant to an existing WC variation by
+	 * SKU equality (`array_search()` against the current variations' SKUs), not
+	 * by the ERP's variant id. When the SKU changes, the match fails, so the
+	 * variant is treated as brand new: a fresh WC_Product_Variation is created
+	 * for it, while the untouched old variation is left over and gets set to
+	 * draft. This test asserts the new variation gets a non-blank SKU (fixed by
+	 * gating set_sku() on the variation's own empty SKU rather than on the
+	 * parent-level $is_new_product flag) and documents the still-present
+	 * orphan/draft side effect as a known follow-up (matching should key off
+	 * the ERP's variant id, not SKU).
+	 */
+	public function test_variant_sku_renamed_on_resync_gets_new_sku() {
+		$item_path = UNIT_TESTS_DATA_PLUGIN_DIR . 'product-variable-new-variant-resync.json';
+		$item      = file_get_contents( $item_path );
+		$item      = json_decode( $item, true )[0];
+
+		$this->settings['catattr'] = 'categoria';
+		$this->settings['catnp']   = 'yes';
+
+		// First sync: variant 9001 comes in with SKU "GENBRA-85D-CH".
+		$result_sync    = PROD::sync_product_item( $this->settings, $item, $this->connapi_erp );
+		$result_prod_id = $result_sync['post_id'];
+
+		$this->assertEquals( 'ok', $result_sync['status'] );
+		$this->assertIsInt( $result_prod_id );
+
+		$product    = wc_get_product( $result_prod_id );
+		$variations = $product->get_children();
+		$this->assertCount( 2, $variations, 'Should have 2 variations after first sync' );
+
+		$old_variation_id = null;
+		foreach ( $variations as $variation_id ) {
+			$prod_variation = new WC_Product_Variation( $variation_id );
+			if ( 'GENBRA-85D-CH' === $prod_variation->get_sku() ) {
+				$old_variation_id = $variation_id;
+			}
+		}
+		$this->assertNotNull( $old_variation_id, 'First sync should create a variation with SKU GENBRA-85D-CH' );
+
+		// Second sync (resync of the SAME product): ERP renamed variant 9001's
+		// SKU from "GENBRA-85D-CH" to "GENBRA-75AA-CH" — same ERP variant id, same attributes.
+		$item_resync                        = $item;
+		$item_resync['variants'][0]['sku']  = 'GENBRA-75AA-CH';
+
+		$result_sync_upd = PROD::sync_product_item( $this->settings, $item_resync, $this->connapi_erp, false, $result_prod_id );
+
+		$this->assertEquals( 'ok', $result_sync_upd['status'] );
+		$this->assertEquals( $result_prod_id, $result_sync_upd['post_id'] );
+
+		$product_updated    = wc_get_product( $result_prod_id );
+		$variations_updated = $product_updated->get_children();
+
+		// Find the variation carrying the renamed variant's barcode (unique across the payload).
+		$renamed_variation      = null;
+		foreach ( $variations_updated as $variation_id ) {
+			$prod_variation = new WC_Product_Variation( $variation_id );
+			if ( '0000000000001' === $prod_variation->get_global_unique_id() ) {
+				$renamed_variation = $prod_variation;
+			}
+		}
+
+		$this->assertNotNull( $renamed_variation, 'A variation for the renamed variant (barcode 0000000000001) should exist after resync' );
+		$this->assertEquals(
+			'GENBRA-75AA-CH',
+			$renamed_variation->get_sku(),
+			'Variation for a variant whose SKU was renamed in the ERP must carry the new SKU, not be left blank'
+		);
+
+		// The stale old variation (SKU GENBRA-85D-CH) should not remain published with its old SKU
+		// still active — WooCommerce would otherwise report it in stock listings using a SKU
+		// that no longer represents the current ERP state.
+		$old_variation_status = get_post_status( $old_variation_id );
+		if ( $renamed_variation->get_id() !== $old_variation_id ) {
+			$this->assertEquals( 'draft', $old_variation_status, 'Orphaned old variation should be set to draft when superseded by a renamed-SKU variant' );
+		}
+
+		wp_delete_post( $result_prod_id, true );
+	}
 }


### PR DESCRIPTION
## Summary

- Adds a regression test (`test_variant_sku_renamed_on_resync_gets_new_sku`) reproducing the scenario in #220: an ERP (Odoo) corrects an existing variant's SKU on resync, and `sync_product_variable()` matches variants to existing WC variations by SKU equality only — so the rename is invisible to `array_search()`, a new variation is created for what is really the same variant, and the old one is drafted.
- On the current `trunk` (post `3bff863`), the new variation no longer gets a **blank** SKU — `set_sku()` now gates on the variation's own empty SKU rather than the parent-level `$is_new_product` flag. This test confirms that.
- The test also documents (asserts, not fixes) the remaining orphan/draft duplication: the old variation is still left behind in `draft` status instead of being reused for the renamed variant.
- Fixture `tests/Data/product-variable-new-variant-resync.json` uses anonymized synthetic data modeled on the real payload shape (no production domain/IDs).

## Follow-up (not in this PR)

Matching variants to existing variations by the ERP's own variant id (`_connect_ecommerce_productid` meta), falling back to SKU only when no id match exists, would prevent the orphan-variation/draft churn entirely. Tracked as a follow-up in #220.

## Test plan

- [ ] `composer test` — `CreateProductVariableTest::test_variant_sku_renamed_on_resync_gets_new_sku` passes on `trunk`
- [ ] Existing `CreateProductVariableTest` suite still passes (no regressions)

Closes/relates to #220.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fshop%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Fwoocommerce-es%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-221-42196ba382027fa8870f3793957db9e4a2ebe47f.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22woocommerce%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->