### PR TITLE
Add npm min-release-age security setting

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -15,6 +15,7 @@ composer.lock
 node_modules/
 package.json
 package-lock.json
+.npmrc
 
 # WordPress
 .wordpress-org

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
## Summary
- Adds `.npmrc` with `min-release-age=7`, delaying installs of npm packages until 7 days after publish to reduce exposure to supply-chain attacks (e.g. compromised maintainer accounts pushing malicious versions that get caught/pulled quickly).
- Excludes `.npmrc` from the distribution build via `.distignore`.

## Test plan
- [x] Verified `.distignore` still lists existing entries correctly with `.npmrc` added under the "Develop" section.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QmUMCWtqkK9WWg5RJkVWQm)_

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fshop%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Fwoocommerce-es%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-226-f034a59b8a171ddd5d72d68ba8b0d42e6318bf13.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22woocommerce%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->