### PR TITLE
Reduce CPU spikes from the automatic product sync cron

### DIFF
--- a/includes/Admin/Import_Products.php
+++ b/includes/Admin/Import_Products.php
@@ -448,33 +448,46 @@ class Import_Products {
 		if ( empty( $this->connapi_erp ) ) {
 			return;
 		}
-		$is_table_sync = ! empty( $this->options['table_sync'] ) ? true : false;
-		if ( $is_table_sync ) {
-			HELPER::check_table_sync( $this->options['table_sync'] );
-		} else {
-			// Check if the API method exists.
-			if ( ! method_exists( $this->connapi_erp, 'get_products_ids_since' ) ) {
-				return;
-			}
-		}
 
-		// Get products to sync.
-		$products_sync = CRON::get_products_sync( $this->settings, $this->options, $this->connapi_erp );
-		if ( empty( $products_sync ) && $is_table_sync ) {
-			CRON::send_sync_ended_products( $this->settings, $this->options['table_sync'], $this->options['name'], $this->options['slug'] );
-			CRON::fill_table_sync( $this->settings, $this->options, $this->connapi_erp );
-			$products_sync = CRON::get_products_sync( $this->settings, $this->options, $this->connapi_erp );
+		// Skip this run if a previous one is still processing (e.g. a slow ERP API made it
+		// overrun the sync interval) — otherwise runs pile up and spike CPU concurrently.
+		$lock_key = 'conecom_sync_products_running_' . $this->options['slug'];
+		if ( get_transient( $lock_key ) ) {
+			return;
 		}
-		if ( ! empty( $products_sync ) ) {
-			foreach ( $products_sync as $product_sync ) {
-				$product_id = isset( $product_sync['prod_id'] ) ? $product_sync['prod_id'] : $product_sync;
+		set_transient( $lock_key, true, 10 * MINUTE_IN_SECONDS );
 
-				$product_api = $this->connapi_erp->get_products( $product_id );
-				$result      = PROD::sync_product_item( $this->settings, $product_api, $this->connapi_erp );
-				if ( $is_table_sync ) {
-					CRON::save_product_sync( $this->options['table_sync'], $result['prod_id'], $this->options['slug'] );
+		try {
+			$is_table_sync = ! empty( $this->options['table_sync'] ) ? true : false;
+			if ( $is_table_sync ) {
+				HELPER::check_table_sync( $this->options['table_sync'] );
+			} else {
+				// Check if the API method exists.
+				if ( ! method_exists( $this->connapi_erp, 'get_products_ids_since' ) ) {
+					return;
 				}
 			}
+
+			// Get products to sync.
+			$products_sync = CRON::get_products_sync( $this->settings, $this->options, $this->connapi_erp );
+			if ( empty( $products_sync ) && $is_table_sync ) {
+				CRON::send_sync_ended_products( $this->settings, $this->options['table_sync'], $this->options['name'], $this->options['slug'] );
+				CRON::fill_table_sync( $this->settings, $this->options, $this->connapi_erp );
+				$products_sync = CRON::get_products_sync( $this->settings, $this->options, $this->connapi_erp );
+			}
+			if ( ! empty( $products_sync ) ) {
+				foreach ( $products_sync as $product_sync ) {
+					$product_id = isset( $product_sync['prod_id'] ) ? $product_sync['prod_id'] : $product_sync;
+
+					$product_api = $this->connapi_erp->get_products( $product_id );
+					$result      = PROD::sync_product_item( $this->settings, $product_api, $this->connapi_erp );
+					if ( $is_table_sync ) {
+						CRON::save_product_sync( $this->options['table_sync'], $result['prod_id'], $this->options['slug'] );
+					}
+				}
+			}
+		} finally {
+			delete_transient( $lock_key );
 		}
 	}
 }

--- a/includes/Helpers/CRON.php
+++ b/includes/Helpers/CRON.php
@@ -106,6 +106,10 @@ class CRON {
 	/**
 	 * Get products to sync
 	 *
+	 * Limited to a smaller batch than the manual import (CONECOM_SYNC_PRODUCTS_PER_BATCH):
+	 * this runs unattended on a timer, so each tick must stay light on CPU/DB instead of
+	 * draining the whole pending queue at once.
+	 *
 	 * @param array  $settings Settings of plugin.
 	 * @param string $options Options of plugin.
 	 * @param object $connapi_erp API Object.
@@ -124,7 +128,7 @@ class CRON {
 		}
 		// Method with table sync.
 		global $wpdb;
-		$limit = defined( 'CONECOM_SYNC_PRODUCTS_PER_BATCH' ) ? CONECOM_SYNC_PRODUCTS_PER_BATCH : 50;
+		$limit = defined( 'CONECOM_SYNC_CRON_BATCH_SIZE' ) ? CONECOM_SYNC_CRON_BATCH_SIZE : 20;
 
 		$results = $wpdb->get_results(
 			$wpdb->prepare(

--- a/readme.txt
+++ b/readme.txt
@@ -224,6 +224,9 @@ This plugin uses the VIES (VAT Information Exchange System) service provided by 
 
 == Changelog ==
 
+= next =
+* Fixed: The automatic sync could spike CPU usage on shared hosting — each cron run processed up to 50 products per tick (the same batch size used for manual imports) and a slow ERP API could make one run overlap with the next. Cron ticks now process a smaller batch (20 products, overridable with the `CONECOM_SYNC_CRON_BATCH_SIZE` constant) and a run is skipped if the previous one is still in progress.
+
 = 3.4.0 =
 * Fixed: Products imported from the ERP always got WooCommerce's standard tax class, ignoring the actual tax configured in the ERP. Products now read the ERP's tax key (e.g. Holded's `s_iva_21`) and resolve it to a WooCommerce tax class via the existing "ERP Tax Type" mapping (WooCommerce > Settings > Tax) — the same mapping already used for the order sync direction.
 * Added: First-install setup wizard guides new users through connecting WooCommerce to their ERP/CRM, configuring EU VAT compliance, setting up AI-assisted product descriptions, and running an initial product sync. Runs automatically on first activation; can be re-run from the "Reset wizard" link on the settings page.


### PR DESCRIPTION
Each cron tick processed up to 50 products (same batch size as manual
imports) and a slow ERP API could let one run overlap the next,
stacking CPU load. Cron ticks now default to a smaller batch of 20
products (overridable via CONECOM_SYNC_CRON_BATCH_SIZE) and a run is
skipped if the previous one is still in progress.

Closes #233

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fshop%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Fwoocommerce-es%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-234-f12433595e86d1f6c2ccddd02910630762ac58f9.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22woocommerce%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->